### PR TITLE
Flaky E2E Tests

### DIFF
--- a/e2e/protractor.conf.js
+++ b/e2e/protractor.conf.js
@@ -8,7 +8,7 @@ const {SpecReporter} = require('jasmine-spec-reporter');
  * @type { import("protractor").Config }
  */
 exports.config = {
-    allScriptsTimeout: 11000,
+    allScriptsTimeout: 22000,
     specs: [
         './src/**/*.e2e-spec.ts',
     ],

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -6,6 +6,7 @@ import { MatAutocompleteHarness } from '@angular/material/autocomplete/testing';
 
 describe('Test App', () => {
     let page: AppPage;
+    const timeout = 6000;
 
     beforeEach(() => {
         page = new AppPage();
@@ -25,7 +26,7 @@ describe('Test App', () => {
         it('should display an integer value', async () => {
             await page.navigateTo('modify');
 
-            const valueEleComp: WebElement = await page.getComponentBySelector('dsp-int-value');
+            const valueEleComp: WebElement = await page.getComponentBySelector('dsp-int-value', timeout);
 
             const intValEleField = await page.getReadValueFieldFromValueComponent(valueEleComp);
             expect(await intValEleField.getText()).toEqual('1');
@@ -36,7 +37,7 @@ describe('Test App', () => {
 
             await page.navigateTo('modify');
 
-            const valueEleComp: WebElement = await page.getComponentBySelector('dsp-int-value');
+            const valueEleComp: WebElement = await page.getComponentBySelector('dsp-int-value', timeout);
 
             const displayEditComp: WebElement = await page.getDisplayEditComponentFromValueComponent(valueEleComp);
 
@@ -56,7 +57,7 @@ describe('Test App', () => {
 
             const EC = browser.ExpectedConditions;
 
-            await browser.wait(EC.presenceOf(element(by.css('.rm-value'))), 3000,
+            await browser.wait(EC.presenceOf(element(by.css('.rm-value'))), timeout,
                 'Wait for read value to be visible.');
 
             const readEle = await page.getReadValueFieldFromValueComponent(valueEleComp);
@@ -122,7 +123,7 @@ describe('Test App', () => {
             await selectOntos.clickOptions({ text: 'The anything ontology'});
 
             // check for the async response from Knora: anything and knora-api ontology
-            await browser.wait(EC.presenceOf(element(by.css('.select-resource-class'))), 3000,
+            await browser.wait(EC.presenceOf(element(by.css('.select-resource-class'))), timeout,
                 'Wait for resource class options to be visible.');
 
             expect(await submitButton.isDisabled()).toBe(true);
@@ -172,7 +173,7 @@ describe('Test App', () => {
             await selectOntos.clickOptions({ text: 'The anything ontology'});
 
             // check for the async response from Knora: anything and knora-api ontology
-            await browser.wait(EC.presenceOf(element(by.css('.select-resource-class'))), 3000,
+            await browser.wait(EC.presenceOf(element(by.css('.select-resource-class'))), timeout,
                 'Wait for resource class options to be visible.');
 
             expect(await submitButton.isDisabled()).toBe(true);
@@ -202,7 +203,7 @@ describe('Test App', () => {
             await input.setValue('testthing');
 
             // check for the async response from Knora: search by label
-            await browser.wait(EC.presenceOf(element(by.css('.resource'))), 3000,
+            await browser.wait(EC.presenceOf(element(by.css('.resource'))), timeout,
                 'Wait for resource options to be visible.');
 
             // check the options

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -80,7 +80,7 @@ describe('Test App', () => {
 
             expect(await submitButton.isDisabled()).toBe(true);
 
-            const selectOntos = await page.getAdvancedSearchOntologySelection(loader);
+            const selectOntos = await page.getAdvancedSearchOntologySelection(loader, timeout);
 
             await selectOntos.open();
 
@@ -126,7 +126,7 @@ describe('Test App', () => {
 
             expect(await submitButton.isDisabled()).toBe(true);
 
-            const selectOntos = await page.getAdvancedSearchOntologySelection(loader);
+            const selectOntos = await page.getAdvancedSearchOntologySelection(loader, timeout);
 
             await selectOntos.clickOptions({ text: 'The anything ontology'});
 
@@ -176,7 +176,7 @@ describe('Test App', () => {
 
             expect(await submitButton.isDisabled()).toBe(true);
 
-            const selectOntos = await page.getAdvancedSearchOntologySelection(loader);
+            const selectOntos = await page.getAdvancedSearchOntologySelection(loader, timeout);
 
             await selectOntos.clickOptions({ text: 'The anything ontology'});
 

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -208,7 +208,7 @@ describe('Test App', () => {
 
             const input = await loader.getHarness(MatInputHarness);
 
-            await input.setValue('testthing');
+            await input.setValue('test');
 
             // check for the async response from Knora: search by label
             await browser.wait(EC.presenceOf(element(by.css('.resource'))), timeout,

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -91,7 +91,7 @@ describe('Test App', () => {
             expect(await ontoOptions[0].getText()).toEqual('The anything ontology');
 
             // anything onto
-            await ontoOptions[0].click();
+            await selectOntos.clickOptions({ text: 'The anything ontology'});
 
             // check for the async response from Knora: anything and knora-api ontology
             await browser.wait(EC.presenceOf(element(by.css('.select-resource-class'))), timeout,
@@ -107,9 +107,11 @@ describe('Test App', () => {
 
             expect(await resClassOptions[2].getText()).toEqual('Thing');
 
-            await resClassOptions[2].click();
+            await resClasses.clickOptions({ text: 'Thing'});
 
             expect(await submitButton.isDisabled()).toBe(false);
+
+            // browser.sleep(200000);
 
         });
 

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -72,6 +72,8 @@ describe('Test App', () => {
         it('should select an ontology and a resource class', async () => {
             await page.navigateTo('advanced-search');
 
+            const EC = browser.ExpectedConditions;
+
             const loader = ProtractorHarnessEnvironment.loader();
 
             const submitButton = await page.getAdvancedSearchSubmitButton(loader);
@@ -90,6 +92,10 @@ describe('Test App', () => {
 
             // anything onto
             await ontoOptions[0].click();
+
+            // check for the async response from Knora: anything and knora-api ontology
+            await browser.wait(EC.presenceOf(element(by.css('.select-resource-class'))), timeout,
+                'Wait for resource class options to be visible.');
 
             const resClasses = await page.getAdvancedSearchResourceClassSelection(loader);
 

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -189,6 +189,13 @@ describe('Test App', () => {
 
             await input.setValue('testthing');
 
+            // check for the async response from Knora: search by label
+
+            const EC = browser.ExpectedConditions;
+
+            await browser.wait(EC.presenceOf(element(by.css('.resource'))), 3000,
+                'Wait for resource options to be visible.');
+
             // check the options
             const autocomplete = await loader.getHarness(MatAutocompleteHarness);
             const options = await autocomplete.getOptions();

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -109,6 +109,8 @@ describe('Test App', () => {
         it('should select an integer property', async () => {
             await page.navigateTo('advanced-search');
 
+            const EC = browser.ExpectedConditions;
+
             const loader = ProtractorHarnessEnvironment.loader();
 
             const submitButton = await page.getAdvancedSearchSubmitButton(loader);
@@ -118,6 +120,10 @@ describe('Test App', () => {
             const selectOntos = await page.getAdvancedSearchOntologySelection(loader);
 
             await selectOntos.clickOptions({ text: 'The anything ontology'});
+
+            // check for the async response from Knora: anything and knora-api ontology
+            await browser.wait(EC.presenceOf(element(by.css('.select-resource-class'))), 3000,
+                'Wait for resource class options to be visible.');
 
             expect(await submitButton.isDisabled()).toBe(true);
 
@@ -153,6 +159,8 @@ describe('Test App', () => {
         it('should select a link property', async () => {
             await page.navigateTo('advanced-search');
 
+            const EC = browser.ExpectedConditions;
+
             const loader = ProtractorHarnessEnvironment.loader();
 
             const submitButton = await page.getAdvancedSearchSubmitButton(loader);
@@ -162,6 +170,10 @@ describe('Test App', () => {
             const selectOntos = await page.getAdvancedSearchOntologySelection(loader);
 
             await selectOntos.clickOptions({ text: 'The anything ontology'});
+
+            // check for the async response from Knora: anything and knora-api ontology
+            await browser.wait(EC.presenceOf(element(by.css('.select-resource-class'))), 3000,
+                'Wait for resource class options to be visible.');
 
             expect(await submitButton.isDisabled()).toBe(true);
 
@@ -190,9 +202,6 @@ describe('Test App', () => {
             await input.setValue('testthing');
 
             // check for the async response from Knora: search by label
-
-            const EC = browser.ExpectedConditions;
-
             await browser.wait(EC.presenceOf(element(by.css('.resource'))), 3000,
                 'Wait for resource options to be visible.');
 

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -47,7 +47,13 @@ export class AppPage {
         return loader.getHarness(MatButtonHarness.with({ selector: '.add-property-button'}));
     }
 
-    getAdvancedSearchOntologySelection(loader: HarnessLoader): Promise<MatSelectHarness> {
+    async getAdvancedSearchOntologySelection(loader: HarnessLoader, timeout): Promise<MatSelectHarness> {
+        const EC = browser.ExpectedConditions;
+
+        // wait for the specified element to be present
+        await browser.wait(EC.presenceOf(element(by.css('app-root .select-ontology'))), timeout,
+            `Wait for .select-ontology to be visible.`);
+
         return loader.getHarness(MatSelectHarness.with({ selector: '.select-ontology' }));
     }
 

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -12,7 +12,13 @@ export class AppPage {
         return element(by.css('app-root span')).getText() as Promise<string>;
     }
 
-    getComponentBySelector(selector: string): WebElement {
+    async getComponentBySelector(selector: string): Promise<WebElement> {
+        const EC = browser.ExpectedConditions;
+
+        // wait for the specified element to be present
+        await browser.wait(EC.presenceOf(element(by.css('app-root ' + selector))), 3000,
+            `Wait for ${selector} to be visible.`);
+
         return element(by.css('app-root ' + selector)).getWebElement();
     }
 

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -4,6 +4,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
 
 export class AppPage {
+
     navigateTo(segment: string) {
         return browser.get(browser.baseUrl + segment) as Promise<any>;
     }
@@ -12,11 +13,11 @@ export class AppPage {
         return element(by.css('app-root span')).getText() as Promise<string>;
     }
 
-    async getComponentBySelector(selector: string): Promise<WebElement> {
+    async getComponentBySelector(selector: string, timeout: number): Promise<WebElement> {
         const EC = browser.ExpectedConditions;
 
         // wait for the specified element to be present
-        await browser.wait(EC.presenceOf(element(by.css('app-root ' + selector))), 3000,
+        await browser.wait(EC.presenceOf(element(by.css('app-root ' + selector))), timeout,
             `Wait for ${selector} to be visible.`);
 
         return element(by.css('app-root ' + selector)).getWebElement();

--- a/projects/dsp-ui/src/lib/search/advanced-search/select-property/specify-property-value/search-link-value/search-link-value.component.html
+++ b/projects/dsp-ui/src/lib/search/advanced-search/select-property/specify-property-value/search-link-value/search-link-value.component.html
@@ -3,7 +3,7 @@
         <input matInput placeholder="resource" aria-label="resource" [matAutocomplete]="auto"
                [formControlName]="'resource'">
         <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayResource">
-            <mat-option *ngFor="let res of resources" [value]="res">
+            <mat-option *ngFor="let res of resources" [value]="res" class="resource">
                 {{res?.label}}
             </mat-option>
         </mat-autocomplete>

--- a/src/app/advanced-search-playground/advanced-search-playground.component.html
+++ b/src/app/advanced-search-playground/advanced-search-playground.component.html
@@ -1,1 +1,1 @@
-<dsp-advanced-search (gravsearchQuery)="submitQuery($event)"></dsp-advanced-search>
+<dsp-advanced-search *ngIf="!loading" (gravsearchQuery)="submitQuery($event)"></dsp-advanced-search>

--- a/src/app/advanced-search-playground/advanced-search-playground.component.spec.ts
+++ b/src/app/advanced-search-playground/advanced-search-playground.component.spec.ts
@@ -1,7 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AdvancedSearchPlaygroundComponent } from './advanced-search-playground.component';
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { DspApiConnectionToken } from '@dasch-swiss/dsp-ui';
+import { ApiResponseData, AuthenticationEndpointV2, LogoutResponse } from '@dasch-swiss/dsp-js';
+import { of } from 'rxjs';
 
 /**
  * Test host component to simulate parent component.
@@ -10,26 +13,45 @@ import { Component, OnInit } from '@angular/core';
     selector: 'dsp-advanced-search',
     template: ``
 })
-class TestHostComponent {}
+class TestHostComponent {
+}
 
 describe('AdvancedSearchPlaygroundComponent', () => {
-  let component: AdvancedSearchPlaygroundComponent;
-  let fixture: ComponentFixture<AdvancedSearchPlaygroundComponent>;
+    let component: AdvancedSearchPlaygroundComponent;
+    let fixture: ComponentFixture<AdvancedSearchPlaygroundComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ AdvancedSearchPlaygroundComponent, TestHostComponent ]
-    })
-    .compileComponents();
-  }));
+    const authSpyObj = {
+        v2: {
+            auth: jasmine.createSpyObj('auth', ['logout'])
+        }
+    };
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AdvancedSearchPlaygroundComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [AdvancedSearchPlaygroundComponent, TestHostComponent],
+            providers: [
+                {
+                    provide: DspApiConnectionToken,
+                    useValue: authSpyObj
+                }
+            ]
+        })
+            .compileComponents();
+    }));
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    beforeEach(() => {
+        const authSpy = TestBed.inject(DspApiConnectionToken);
+
+        (authSpy.v2.auth as jasmine.SpyObj<AuthenticationEndpointV2>).logout.and.returnValue(
+            of({} as ApiResponseData<LogoutResponse>)
+        );
+
+        fixture = TestBed.createComponent(AdvancedSearchPlaygroundComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/src/app/advanced-search-playground/advanced-search-playground.component.ts
+++ b/src/app/advanced-search-playground/advanced-search-playground.component.ts
@@ -1,23 +1,35 @@
-import { Component, OnInit } from '@angular/core';
-import { AdvancedSearchParamsService } from '@dasch-swiss/dsp-ui';
+import { Component, Inject, OnInit } from '@angular/core';
+import { AdvancedSearchParamsService, DspApiConnectionToken } from '@dasch-swiss/dsp-ui';
+import { ApiResponseData, ApiResponseError, KnoraApiConnection, LogoutResponse } from '@dasch-swiss/dsp-js';
 
 @Component({
-  selector: 'app-advanced-search-playground',
-  templateUrl: './advanced-search-playground.component.html',
-  styleUrls: ['./advanced-search-playground.component.scss']
+    selector: 'app-advanced-search-playground',
+    templateUrl: './advanced-search-playground.component.html',
+    styleUrls: ['./advanced-search-playground.component.scss']
 })
 export class AdvancedSearchPlaygroundComponent implements OnInit {
 
-  constructor(private _advancedSearchParamsService: AdvancedSearchParamsService) { }
+    loading: boolean;
 
-  ngOnInit(): void {
+    constructor(private _advancedSearchParamsService: AdvancedSearchParamsService,
+                @Inject(DspApiConnectionToken) private knoraApiConnection: KnoraApiConnection) {
+    }
 
-  }
+    ngOnInit(): void {
+        this.loading = true;
+        this.knoraApiConnection.v2.auth.logout().subscribe(
+            (response: ApiResponseData<LogoutResponse>) => {
+                this.loading = false;
+            },
+            (error: ApiResponseError) => {
+                console.error(error);
+            });
+    }
 
-  submitQuery(gravsearchQuery: string) {
-      console.log('Output: ', gravsearchQuery);
+    submitQuery(gravsearchQuery: string) {
+        console.log('Output: ', gravsearchQuery);
 
-      console.log('search params', this._advancedSearchParamsService.getSearchParams().generateGravsearch(1));
-  }
+        console.log('search params', this._advancedSearchParamsService.getSearchParams().generateGravsearch(1));
+    }
 
 }


### PR DESCRIPTION
resolves https://dasch.myjetbrains.com/youtrack/issue/DSP-457

The E2E tests for the advanced search failed from time to time because async operations were no taken into account properly. For example, when an ontology has been selected, the UI has to get the ontology or ontologies from Knora. This could take some time. Unfortunately, the Harnesses in E2E tests [do not implement the necessary functionality yet](https://github.com/angular/components/issues/18375). 

As a solution, I use `browser.ExpectedConditions`: information fetched from Knora is expected to be displayed in the GUI within a defined time limit. Once the condition is met, the tests continues and further assertions can be checked safely.