### PR TITLE
FIX: hide the add button for an XML text property

### DIFF
--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.html
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.html
@@ -35,7 +35,11 @@
                         </dsp-add-value>
                     </div>
                     <!-- Add button -->
-                    <div *ngIf="addButtonIsVisible && prop.guiDef.cardinality !== 1 && propID !== prop.propDef.id">
+                    <!-- temporary hack to hide add button for an XML value -->
+                    <div *ngIf="prop.guiDef.propertyIndex !== 'http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext' &&
+                        addButtonIsVisible &&
+                        prop.guiDef.cardinality !== 1 &&
+                        propID !== prop.propDef.id">
                         <button class="create" (click)="showAddValueForm(prop)" title="Add a new value">
                             <mat-icon>add_box</mat-icon>
                         </button>

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.spec.ts
@@ -219,7 +219,7 @@ describe('PropertyViewComponent', () => {
 
         it('should show an add button under each property that has a value component and for which the cardinality is not 1', () => {
             const addButtons = propertyViewComponentDe.queryAll(By.css('button.create'));
-            expect(addButtons.length).toEqual(14);
+            expect(addButtons.length).toEqual(13);
 
         });
 
@@ -236,7 +236,7 @@ describe('PropertyViewComponent', () => {
             const addButtons = propertyViewComponentDe.queryAll(By.css('button.create'));
 
             // the add button for the property with the open add value form is hidden
-            expect(addButtons.length).toEqual(13);
+            expect(addButtons.length).toEqual(12);
 
             expect(propertyViewComponentDe.query(By.css('.add-value'))).toBeDefined();
 


### PR DESCRIPTION
Temporary "fix" to hide the add button for an XML text property as long as there is no value component for it