### PR TITLE
Viewer: Use span Elements instead of div and p in Read Mode

### DIFF
--- a/projects/dsp-ui/src/assets/style/_viewer.scss
+++ b/projects/dsp-ui/src/assets/style/_viewer.scss
@@ -10,8 +10,8 @@
 
 .read-mode-view {
   font: 400 15px/24px sans-serif;
-  p {
-    margin: 0px;
+  .rm-value {
+    display: block;
   }
 }
 

--- a/projects/dsp-ui/src/assets/style/_viewer.scss
+++ b/projects/dsp-ui/src/assets/style/_viewer.scss
@@ -10,8 +10,9 @@
 
 .read-mode-view {
   font: 400 15px/24px sans-serif;
-  .rm-value {
+  .rm-value, .rm-comment {
     display: block;
+    margin: 0px
   }
 }
 

--- a/projects/dsp-ui/src/assets/style/_viewer.scss
+++ b/projects/dsp-ui/src/assets/style/_viewer.scss
@@ -12,7 +12,7 @@
   font: 400 15px/24px sans-serif;
   .rm-value, .rm-comment {
     display: block;
-    margin: 0px
+    margin: 0px;
   }
 }
 

--- a/projects/dsp-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/boolean-value/boolean-value.component.html
@@ -1,7 +1,7 @@
-<div *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <p class="rm-value">{{valueFormControl.value | formattedBoolean:preferredDisplayType}}</p>
-    <p class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</p>
-</div>
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+    <span class="rm-value">{{valueFormControl.value | formattedBoolean:preferredDisplayType}}</span>
+    <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
+</span>
 <ng-template #showForm>
     <span [formGroup]="form" (ngSubmit)="onSubmit()">
         <mat-checkbox [formControlName]="'booleanValue'" class="value boolValue child-value-component">

--- a/projects/dsp-ui/src/lib/viewer/values/color-value/color-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/color-value/color-value.component.html
@@ -1,15 +1,15 @@
-<div *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <p>Hex value:</p>
-    <p class="rm-value">{{ valueFormControl.value }}</p>
-    <p>Preview:</p>
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+    <span>Hex value:</span>
+    <span class="rm-value">{{ valueFormControl.value }}</span>
+    <span>Preview:</span>
     <div
         class="color-preview"
         [style.background-color]="valueFormControl.value"
     ></div>
-    <p class="rm-comment" *ngIf="shouldShowComment">
+    <span class="rm-comment" *ngIf="shouldShowComment">
         {{ commentFormControl.value }}
-    </p>
-</div>
+    </span>
+</span>
 <ng-template #showForm>
     <span [formGroup]="form">
         <mat-form-field class="large-field color-field child-value-component" floatLabel="never">

--- a/projects/dsp-ui/src/lib/viewer/values/date-value/date-input/date-input.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/date-value/date-input/date-input.component.html
@@ -16,7 +16,7 @@
       <mat-datepicker #picker1 [calendarHeaderComponent]="calendarHeaderComponent"></mat-datepicker>
     </dsp-jdn-datepicker>
   </mat-form-field>
-  <mat-checkbox [formControlName]="'isPeriod'" (change)="_handleInput()"></mat-checkbox>
+  <mat-checkbox [formControlName]="'isPeriod'" (change)="_handleInput()" matTooltip="Period"></mat-checkbox>
   <mat-form-field *ngIf="isPeriodControl.value" class="end child-input-component">
     <span class="calendar">{{endDateControl.value?.calendarName}}</span>
     <dsp-jdn-datepicker [activeCalendar]="endDateControl.value?.calendarName">

--- a/projects/dsp-ui/src/lib/viewer/values/date-value/date-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/date-value/date-value.component.html
@@ -1,22 +1,22 @@
-<div *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <div *ngIf="valueFormControl.value?.end; else date">
-        <p class="rm-value date-start">
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+    <span *ngIf="valueFormControl.value?.end; else date">
+        <span class="rm-value date-start">
             <span *ngIf="labels">Period Start: </span>
             {{valueFormControl.value?.start | knoraDate:ontologyDateFormat:displayOptions}}
-        </p>
-        <p class="rm-value date-end">
+        </span>
+        <span class="rm-value date-end">
             <span *ngIf="labels">Period End: </span>
             {{valueFormControl.value?.end | knoraDate:ontologyDateFormat:displayOptions}}
-        </p>
-    </div>
+        </span>
+    </span>
     <ng-template #date>
-        <p class="rm-value">
+        <span class="rm-value">
             <span *ngIf="labels">Date: </span>
             {{valueFormControl.value | knoraDate:ontologyDateFormat:displayOptions}}
-        </p>
-        <p class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</p>
+        </span>
     </ng-template>
-</div>
+    <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
+</span>
 <ng-template #showForm>
     <span [formGroup]="form">
         <mat-form-field class="large-field child-value-component" floatLabel="never">

--- a/projects/dsp-ui/src/lib/viewer/values/date-value/date-value.component.scss
+++ b/projects/dsp-ui/src/lib/viewer/values/date-value/date-value.component.scss
@@ -11,3 +11,7 @@
     }
   }
 }
+
+.date-start, .date-end {
+    display: block;
+}

--- a/projects/dsp-ui/src/lib/viewer/values/decimal-value/decimal-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/decimal-value/decimal-value.component.html
@@ -1,7 +1,7 @@
-<div *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <p class="rm-value">{{valueFormControl.value}}</p>
-    <p class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</p>
-</div>
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+    <span class="rm-value">{{valueFormControl.value}}</span>
+    <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
+</span>
 <ng-template #showForm>
     <span [formGroup]="form">
         <mat-form-field class="large-field child-value-component" floatLabel="never">

--- a/projects/dsp-ui/src/lib/viewer/values/geoname-value/geoname-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/geoname-value/geoname-value.component.html
@@ -1,13 +1,13 @@
-<div *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <p class="rm-value">{{ valueFormControl.value }}</p>
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+    <span class="rm-value">{{ valueFormControl.value }}</span>
     <button class="more-info" mat-icon-button matSuffix (click)="openInfo()" [attr.aria-label]="'Open in geonames.org'"
         title="Open in geonames.org">
         <mat-icon>launch</mat-icon>
     </button>
-    <p class="rm-comment" *ngIf="shouldShowComment">
+    <span class="rm-comment" *ngIf="shouldShowComment">
         {{ commentFormControl.value }}
-    </p>
-</div>
+    </span>
+</span>
 <ng-template #showForm>
     <span [formGroup]="form" class="form-fields-container">
         <mat-form-field class="large-field child-value-component" floatLabel="never">

--- a/projects/dsp-ui/src/lib/viewer/values/int-value/int-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/int-value/int-value.component.html
@@ -1,7 +1,7 @@
-<div *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <p class="rm-value">{{valueFormControl.value}}</p>
-    <p class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</p>
-</div>
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+    <span class="rm-value">{{valueFormControl.value}}</span>
+    <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
+</span>
 <ng-template #showForm>
     <span [formGroup]="form">
         <mat-form-field class="large-field child-value-component" floatLabel="never">

--- a/projects/dsp-ui/src/lib/viewer/values/interval-value/interval-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/interval-value/interval-value.component.html
@@ -1,8 +1,8 @@
-<div *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-  <p class="rm-value interval-start">Start: {{valueFormControl.value?.start}}</p>
-  <p class="rm-value interval-end">End: {{valueFormControl.value?.end}}</p>
-  <p class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</p>
-</div>
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+  <span class="rm-value interval-start">Start: {{valueFormControl.value?.start}}</span>
+  <span class="rm-value interval-end">End: {{valueFormControl.value?.end}}</span>
+  <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
+</span>
 <ng-template #showForm>
   <span [formGroup]="form">
       <mat-form-field class="large-field child-value-component" floatLabel="never">

--- a/projects/dsp-ui/src/lib/viewer/values/interval-value/interval-value.component.scss
+++ b/projects/dsp-ui/src/lib/viewer/values/interval-value/interval-value.component.scss
@@ -11,3 +11,7 @@
         }
     }
 }
+
+.interval-start, .interval-end {
+    display: block;
+}

--- a/projects/dsp-ui/src/lib/viewer/values/link-value/link-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/link-value/link-value.component.html
@@ -1,9 +1,9 @@
-<div *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <p class="rm-value" (click)="refResClicked()">
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+    <span class="rm-value" (click)="refResClicked()">
         <a class="link">{{valueFormControl.value?.label}}</a>
-    </p>
-  <p class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</p>
-</div>
+    </span>
+  <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
+</span>
 <ng-template #showForm>
   <span [formGroup]="form">
     <mat-form-field class="child-value-component" floatLabel="never">

--- a/projects/dsp-ui/src/lib/viewer/values/list-value/list-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/list-value/list-value.component.html
@@ -29,10 +29,10 @@
         <span class="custom-error-message">This value already exists for this property. Duplicate values are not allowed.</span>
     </mat-error>
 </span>
-<div *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <p class="rm-value">{{valueFormControl.value}}</p>
-    <p class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</p>
-</div>
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+    <span class="rm-value">{{valueFormControl.value}}</span>
+    <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
+</span>
 <ng-template #showForm>
     <span [formGroup]="form">
     <mat-form-field class="large-field child-value-component" *ngIf="mode === 'read'" floatLabel="never">

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-string/text-value-as-string.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-string/text-value-as-string.component.html
@@ -1,7 +1,7 @@
-<div *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <p class="rm-value">{{valueFormControl.value}}</p>
-    <p class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</p>
-</div>
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+    <span class="rm-value">{{valueFormControl.value}}</span>
+    <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
+</span>
 <ng-template #showForm>
     <span [formGroup]="form">
         <mat-form-field class="large-field child-value-component" floatLabel="never">

--- a/projects/dsp-ui/src/lib/viewer/values/time-value/time-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/time-value/time-value.component.html
@@ -1,8 +1,8 @@
-<div *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-  <p class="rm-value date">Date: {{valueFormControl.value | date}}</p>
-  <p class="rm-value time">Time: {{valueFormControl.value | date:"HH:mm"}}</p>
-  <p class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</p>
-</div>
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+  <span class="rm-value date">Date: {{valueFormControl.value | date}}</span>
+  <span class="rm-value time">Time: {{valueFormControl.value | date:"HH:mm"}}</span>
+  <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
+</span>
 <ng-template #showForm>
   <span [formGroup]="form" class="parent-component-wrapper">
       <mat-form-field class="large-field child-value-component" floatLabel="never">

--- a/projects/dsp-ui/src/lib/viewer/values/time-value/time-value.component.scss
+++ b/projects/dsp-ui/src/lib/viewer/values/time-value/time-value.component.scss
@@ -11,3 +11,7 @@
         }
     }
 }
+
+.date, .time {
+    display: block;
+}

--- a/projects/dsp-ui/src/lib/viewer/values/uri-value/uri-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/uri-value/uri-value.component.html
@@ -1,9 +1,9 @@
-<div *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <p class="rm-value">
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+    <span class="rm-value">
         <a class="link" target="_blank" href="{{valueFormControl.value}}">{{ label ? label : valueFormControl.value}}</a>
-    </p>
-    <p class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</p>
-</div>
+    </span>
+    <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
+</span>
 <ng-template #showForm>
     <span [formGroup]="form">
         <mat-form-field class="large-field child-value-component" floatLabel="never">

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.scss
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.scss
@@ -61,7 +61,6 @@
       }
 
       .property-value {
-        padding-top: 5px;
         grid-column: 2 / span 3;
       }
     }


### PR DESCRIPTION
resolves https://dasch.myjetbrains.com/youtrack/issue/DSP-587

This PR substitutes `<div>` and `<p>` elements for `<span>` elements in read-mode.
This should give users of the value components more flexibility when using them in an app.

For some components (date, timestamp, interval), I added some component specific CSS. I added general instructions for the `rm-value` class in the viewer's CSS since it is applied to all value components. 

However, I am still not sure how easy it would be to overwrite the styles provided by a lib on the app level.
Consider the following example from BEOL:

![Screenshot 2020-09-10 at 10 28 53](https://user-images.githubusercontent.com/6000023/92701591-75f2c880-f350-11ea-8c05-8525058435b6.png)

Because of _viewer.scss:
```css
.read-mode-view {
  font: 400 15px/24px sans-serif;
  .rm-value {
    display: block;
  }
}
```

there is some extra space for the date value. But it is needed because otherwise the comment would be directly attached to the value. 