### PR TITLE
Integrate Ckeditor into Property View

### DIFF
--- a/projects/dsp-ui/src/lib/viewer/operations/add-value/add-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/operations/add-value/add-value.component.html
@@ -3,6 +3,7 @@
         <span [ngSwitch]="resourcePropertyDefinition.objectType">
             <dsp-text-value-as-string #createVal *ngSwitchCase="'ReadTextValueAsString'" [mode]="mode"></dsp-text-value-as-string>
             <dsp-text-value-as-html #createVal *ngSwitchCase="'ReadTextValueAsHtml'" [mode]="mode"></dsp-text-value-as-html>
+            <dsp-text-value-as-xml #createVal *ngSwitchCase="'ReadTextValueAsXml'" [mode]="mode"></dsp-text-value-as-xml>
             <dsp-int-value #createVal *ngSwitchCase="constants.IntValue" [mode]="mode"></dsp-int-value>
             <dsp-boolean-value #createVal *ngSwitchCase="constants.BooleanValue" [mode]="mode"></dsp-boolean-value>
             <dsp-uri-value #createVal *ngSwitchCase="constants.UriValue" [mode]="mode"></dsp-uri-value>

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
@@ -7,6 +7,7 @@
             <!-- display value is cast as 'any' because the compiler cannot infer the value type expected by the child component -->
             <dsp-text-value-as-string class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsString'" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-text-value-as-string>
             <dsp-text-value-as-html class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsHtml'" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-text-value-as-html>
+            <dsp-text-value-as-xml class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsXml'" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-text-value-as-xml>
             <dsp-int-value class="parent-value-component" #displayVal *ngSwitchCase="constants.IntValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-int-value>
             <dsp-boolean-value class="parent-value-component" #displayVal *ngSwitchCase="constants.BooleanValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-boolean-value>
             <dsp-uri-value class="parent-value-component" #displayVal *ngSwitchCase="constants.UriValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-uri-value>

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -512,7 +512,7 @@ describe('DisplayEditComponent', () => {
     it('should return the type of a integer value as not readonly', () => {
       expect(valueTypeService.getValueTypeOrClass(testHostComponent.displayEditValueComponent.displayValue)).toEqual(Constants.IntValue);
 
-      expect(valueTypeService.isReadOnly(Constants.IntValue)).toBe(false);
+      expect(valueTypeService.isReadOnly(Constants.IntValue, testHostComponent.displayEditValueComponent.displayValue)).toBe(false);
     });
 
     it('should return the class of a html text value as readonly', () => {
@@ -522,7 +522,7 @@ describe('DisplayEditComponent', () => {
 
       expect(valueTypeService.getValueTypeOrClass(htmlTextVal)).toEqual('ReadTextValueAsHtml');
 
-      expect(valueTypeService.isReadOnly('ReadTextValueAsHtml')).toBe(true);
+      expect(valueTypeService.isReadOnly('ReadTextValueAsHtml', htmlTextVal)).toBe(true);
 
     });
 
@@ -533,7 +533,7 @@ describe('DisplayEditComponent', () => {
 
       expect(valueTypeService.getValueTypeOrClass(plainTextVal)).toEqual('ReadTextValueAsString');
 
-      expect(valueTypeService.isReadOnly('ReadTextValueAsString')).toBe(false);
+      expect(valueTypeService.isReadOnly('ReadTextValueAsString', plainTextVal)).toBe(false);
 
     });
 

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -526,17 +526,6 @@ describe('DisplayEditComponent', () => {
 
     });
 
-    it('should return the class of an XML text value as readonly', () => {
-
-      const xmlTextVal = new ReadTextValueAsXml();
-      xmlTextVal.type = Constants.TextValue;
-
-      expect(valueTypeService.getValueTypeOrClass(xmlTextVal)).toEqual('ReadTextValueAsXml');
-
-      expect(valueTypeService.isReadOnly('ReadTextValueAsXml')).toBe(true);
-
-    });
-
     it('should return the type of a plain text value as not readonly', () => {
 
       const plainTextVal = new ReadTextValueAsString();

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
@@ -125,7 +125,7 @@ export class DisplayEditComponent implements OnInit {
 
         this.valueTypeOrClass = this._valueTypeService.getValueTypeOrClass(this.displayValue);
 
-        this.readOnlyValue = this._valueTypeService.isReadOnly(this.valueTypeOrClass);
+        this.readOnlyValue = this._valueTypeService.isReadOnly(this.valueTypeOrClass, this.displayValue);
 
         this._dspApiConnection.admin.usersEndpoint.getUserByIri(this.displayValue.attachedToUser).subscribe(
             (response: ApiResponseData<UserResponse>) => {

--- a/projects/dsp-ui/src/lib/viewer/services/value-type.service.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/services/value-type.service.spec.ts
@@ -36,14 +36,14 @@ describe('ValueTypeService', () => {
             const readTextValueAsString = new ReadTextValueAsString();
             readTextValueAsString.type = 'http://api.knora.org/ontology/knora-api/v2#TextValue';
             const valueClass = service.getValueTypeOrClass(readTextValueAsString);
-            expect(service.isReadOnly(valueClass)).toBeFalsy();
+            expect(service.isReadOnly(valueClass, readTextValueAsString)).toBeFalsy();
         });
 
         it('should mark ReadTextValueAsHtml as ReadOnly', () => {
             const readTextValueAsHtml = new ReadTextValueAsHtml();
             readTextValueAsHtml.type = 'http://api.knora.org/ontology/knora-api/v2#TextValue';
             const valueClass = service.getValueTypeOrClass(readTextValueAsHtml);
-            expect(service.isReadOnly(valueClass)).toBeTruthy();
+            expect(service.isReadOnly(valueClass, readTextValueAsHtml)).toBeTruthy();
         });
     });
 

--- a/projects/dsp-ui/src/lib/viewer/services/value-type.service.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/services/value-type.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { ReadIntValue, ReadTextValueAsHtml, ReadTextValueAsString } from '@dasch-swiss/dsp-js';
+import { ReadIntValue, ReadTextValueAsHtml, ReadTextValueAsString, ReadTextValueAsXml } from '@dasch-swiss/dsp-js';
 import { ValueTypeService } from './value-type.service';
 
 describe('ValueTypeService', () => {
@@ -44,6 +44,22 @@ describe('ValueTypeService', () => {
             readTextValueAsHtml.type = 'http://api.knora.org/ontology/knora-api/v2#TextValue';
             const valueClass = service.getValueTypeOrClass(readTextValueAsHtml);
             expect(service.isReadOnly(valueClass, readTextValueAsHtml)).toBeTruthy();
+        });
+
+        it('should not mark ReadTextValueAsXml with standard mapping as ReadOnly', () => {
+            const readTextValueAsXml = new ReadTextValueAsXml();
+            readTextValueAsXml.type = 'http://api.knora.org/ontology/knora-api/v2#TextValue';
+            readTextValueAsXml.mapping = 'http://rdfh.ch/standoff/mappings/StandardMapping';
+            const valueClass = service.getValueTypeOrClass(readTextValueAsXml);
+            expect(service.isReadOnly(valueClass, readTextValueAsXml)).toBeFalsy();
+        });
+
+        it('should mark ReadTextValueAsXml with custom mapping as ReadOnly', () => {
+            const readTextValueAsXml = new ReadTextValueAsXml();
+            readTextValueAsXml.type = 'http://api.knora.org/ontology/knora-api/v2#TextValue';
+            readTextValueAsXml.mapping = 'http://rdfh.ch/standoff/mappings/CustomMapping';
+            const valueClass = service.getValueTypeOrClass(readTextValueAsXml);
+            expect(service.isReadOnly(valueClass, readTextValueAsXml)).toBeTruthy();
         });
     });
 

--- a/projects/dsp-ui/src/lib/viewer/services/value-type.service.ts
+++ b/projects/dsp-ui/src/lib/viewer/services/value-type.service.ts
@@ -56,7 +56,7 @@ export class ValueTypeService {
         if (resourcePropDef.guiElement === 'http://api.knora.org/ontology/salsah-gui/v2#SimpleText') {
             return this._readTextValueAsString;
         } else if (resourcePropDef.guiElement === 'http://api.knora.org/ontology/salsah-gui/v2#Richtext') {
-            return this._readTextValueAsHtml;
+            return this._readTextValueAsXml;
         } else {
             throw new Error(`unknown TextValue class ${resourcePropDef}`);
         }

--- a/projects/dsp-ui/src/lib/viewer/services/value-type.service.ts
+++ b/projects/dsp-ui/src/lib/viewer/services/value-type.service.ts
@@ -88,7 +88,6 @@ export class ValueTypeService {
      */
     isReadOnly(valueTypeOrClass: string): boolean {
         return valueTypeOrClass === this._readTextValueAsHtml ||
-            valueTypeOrClass === this._readTextValueAsXml ||
             valueTypeOrClass === this.constants.GeomValue;
     }
 }

--- a/projects/dsp-ui/src/lib/viewer/services/value-type.service.ts
+++ b/projects/dsp-ui/src/lib/viewer/services/value-type.service.ts
@@ -85,9 +85,14 @@ export class ValueTypeService {
      * Determines if the given value is readonly.
      *
      * @param valueTypeOrClass the type or class of the given value.
+     * @param value the given value.
      */
-    isReadOnly(valueTypeOrClass: string): boolean {
+    isReadOnly(valueTypeOrClass: string, value: ReadValue): boolean {
+        const xmlValueNonStandardMapping
+            = valueTypeOrClass === this._readTextValueAsXml
+            && (value instanceof ReadTextValueAsXml && value.mapping !== 'http://rdfh.ch/standoff/mappings/StandardMapping');
+
         return valueTypeOrClass === this._readTextValueAsHtml ||
-            valueTypeOrClass === this.constants.GeomValue;
+            valueTypeOrClass === this.constants.GeomValue || xmlValueNonStandardMapping;
     }
 }

--- a/projects/dsp-ui/src/lib/viewer/values/base-value.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/base-value.component.ts
@@ -52,6 +52,10 @@ export abstract class BaseValueComponent {
      * @param curValue Current value.
      */
     standardValueComparisonFunc(initValue: any, curValue: any): boolean {
+        // if values are strings, trim them
+        initValue = typeof initValue === 'string' ? initValue.trim() : initValue;
+        curValue = typeof curValue === 'string' ? curValue.trim() : curValue;
+
         return initValue === curValue;
     }
 
@@ -69,6 +73,7 @@ export abstract class BaseValueComponent {
                 const invalid = this.standardValueComparisonFunc(initValue, control.value)
                     && (initComment === commentFormControl.value || (initComment === null && commentFormControl.value === ''));
 
+                console.log('validity: ', !invalid);
                 return invalid ? { valueNotChanged: { value: control.value } } : null;
             };
         };

--- a/projects/dsp-ui/src/lib/viewer/values/base-value.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/base-value.component.ts
@@ -52,10 +52,6 @@ export abstract class BaseValueComponent {
      * @param curValue Current value.
      */
     standardValueComparisonFunc(initValue: any, curValue: any): boolean {
-        // if values are strings, trim them
-        initValue = typeof initValue === 'string' ? initValue.trim() : initValue;
-        curValue = typeof curValue === 'string' ? curValue.trim() : curValue;
-
         return initValue === curValue;
     }
 
@@ -73,7 +69,6 @@ export abstract class BaseValueComponent {
                 const invalid = this.standardValueComparisonFunc(initValue, control.value)
                     && (initComment === commentFormControl.value || (initComment === null && commentFormControl.value === ''));
 
-                console.log('validity: ', !invalid);
                 return invalid ? { valueNotChanged: { value: control.value } } : null;
             };
         };

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
@@ -24,7 +24,7 @@
         </span>
     </div>
     <ng-template #noConfig>
-        No mapping or apt configuration was provided for "xmlTransform" in the app's configuration object.
+        No class was provided for CKEditor.
     </ng-template>
 </ng-template>
 

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
@@ -1,5 +1,8 @@
 <span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <span class="rm-value" [innerHTML]="valueFormControl.value"></span>
+    <span *ngIf="this.displayValue?.mapping === standardMapping; else sourceMode" class="rm-value" [innerHTML]="valueFormControl.value"></span>
+    <ng-template #sourceMode class="rm-value">
+        <span>{{valueFormControl.value}}</span>
+    </ng-template>
     <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
 </span>
 <ng-template #showForm>

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
@@ -1,5 +1,5 @@
 <span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <span *ngIf="this.displayValue?.mapping === standardMapping; else sourceMode" class="rm-value" [innerHTML]="valueFormControl.value"></span>
+    <div *ngIf="this.displayValue?.mapping === standardMapping; else sourceMode" class="rm-value" [innerHTML]="valueFormControl.value"></div>
     <ng-template #sourceMode>
         <span class="rm-value">{{displayValue?.xml}}</span>
     </ng-template>

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
@@ -1,18 +1,27 @@
-<div *ngIf="editor; else noConfig" [formGroup]="form">
-    <ckeditor formControlName="xmlValue" [config]="editorConfig" [editor]="editor"></ckeditor>
-    <mat-form-field class="large-field value-component-comment">
-            <textarea matInput
-                      cdkTextareaAutosize
-                      cdkAutosizeMinRows="1"
-                      cdkAutosizeMaxRows="6"
-                      [formControlName]="'comment'"
-                      class="comment"
-                      placeholder="Comment"
-                      type="text"
-                      spellcheck="false">
-            </textarea>
-    </mat-form-field>
-</div>
-<ng-template #noConfig>
-    No mapping or apt configuration was provided for "xmlTransform" in the app's configuration object.
+<span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
+    <span class="rm-value" [innerHTML]="valueFormControl.value"></span>
+    <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
+</span>
+<ng-template #showForm>
+    <div *ngIf="editor; else noConfig" [formGroup]="form">
+        <span [formGroup]="form">
+            <ckeditor [formControlName]="'xmlValue'" [config]="editorConfig" [editor]="editor"></ckeditor>
+            <mat-form-field class="large-field value-component-comment">
+                    <textarea matInput
+                            cdkTextareaAutosize
+                            cdkAutosizeMinRows="1"
+                            cdkAutosizeMaxRows="6"
+                            [formControlName]="'comment'"
+                            class="comment"
+                            placeholder="Comment"
+                            type="text"
+                            spellcheck="false">
+                    </textarea>
+            </mat-form-field>
+        </span>
+    </div>
+    <ng-template #noConfig>
+        No mapping or apt configuration was provided for "xmlTransform" in the app's configuration object.
+    </ng-template>
 </ng-template>
+

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
@@ -1,7 +1,7 @@
 <span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
     <span *ngIf="this.displayValue?.mapping === standardMapping; else sourceMode" class="rm-value" [innerHTML]="valueFormControl.value"></span>
-    <ng-template #sourceMode class="rm-value">
-        <span>{{valueFormControl.value}}</span>
+    <ng-template #sourceMode>
+        <span class="rm-value">{{displayValue?.xml}}</span>
     </ng-template>
     <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>
 </span>

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.scss
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.scss
@@ -5,3 +5,7 @@
 ::ng-deep .ck-content code {
   font-family: monospace;
 }
+
+.rm-value p {
+  margin: 0;
+}

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.scss
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.scss
@@ -6,6 +6,8 @@
   font-family: monospace;
 }
 
-.rm-value p {
-  margin: 0;
+.rm-value {
+  ::ng-deep p {
+    margin: 0;
+  }
 }

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.spec.ts
@@ -105,23 +105,6 @@ class TestHostCreateValueComponent implements OnInit {
 
 describe('TextValueAsXMLComponent', () => {
 
-    const appInitServiceMock = {
-        config: {
-            xmlTransform: {
-                'http://rdfh.ch/standoff/mappings/StandardMapping': {
-                    '<hr>': '<hr/>',
-                    '</hr>': '',
-                    '<s>': '<strike>',
-                    '</s>': '</strike>',
-                    '<i>': '<em>',
-                    '</i>': '</em>',
-                    '<figure class="table">': '',
-                    '</figure>': ''
-                }
-            }
-        }
-    };
-
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             declarations: [
@@ -134,9 +117,6 @@ describe('TextValueAsXMLComponent', () => {
                 ReactiveFormsModule,
                 MatInputModule,
                 BrowserAnimationsModule
-            ],
-            providers: [
-                {provide: AppInitService, useValue: appInitServiceMock}
             ]
         })
             .compileComponents();

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.spec.ts
@@ -145,6 +145,12 @@ describe('TextValueAsXMLComponent', () => {
     describe('display and edit a text value with xml markup', () => {
         let testHostComponent: TestHostDisplayValueComponent;
         let testHostFixture: ComponentFixture<TestHostDisplayValueComponent>;
+
+        let valueComponentDe: DebugElement;
+
+        let valueReadModeDebugElement: DebugElement;
+        let valueReadModeNativeElement;
+
         let ckeditorDe: DebugElement;
 
         beforeEach(() => {
@@ -153,8 +159,14 @@ describe('TextValueAsXMLComponent', () => {
             testHostFixture.detectChanges();
 
             const hostCompDe = testHostFixture.debugElement;
+            valueComponentDe = hostCompDe.query(By.directive(TextValueAsXMLComponent));
 
-            ckeditorDe = hostCompDe.query(By.directive(TestCKEditorComponent));
+            valueReadModeDebugElement = valueComponentDe.query(By.css('.rm-value'));
+            valueReadModeNativeElement = valueReadModeDebugElement.nativeElement;
+
+            // reset before each it
+            ckeditorDe = undefined;
+
         });
 
         it('should display an existing value', () => {
@@ -165,9 +177,7 @@ describe('TextValueAsXMLComponent', () => {
 
             expect(testHostComponent.inputValueComponent.mode).toEqual('read');
 
-            expect(testHostComponent.inputValueComponent.valueFormControl.disabled).toBeTruthy();
-
-            expect(ckeditorDe.componentInstance.value).toEqual('\n<p>test with <strong>markup</strong></p>');
+            expect(valueReadModeNativeElement.innerHTML).toEqual('\n<p>test with <strong>markup</strong></p>');
 
         });
 
@@ -176,6 +186,8 @@ describe('TextValueAsXMLComponent', () => {
             testHostComponent.mode = 'update';
 
             testHostFixture.detectChanges();
+
+            ckeditorDe = valueComponentDe.query(By.directive(TestCKEditorComponent));
 
             expect(testHostComponent.inputValueComponent.mode).toEqual('update');
 
@@ -208,6 +220,8 @@ describe('TextValueAsXMLComponent', () => {
 
             testHostFixture.detectChanges();
 
+            ckeditorDe = valueComponentDe.query(By.directive(TestCKEditorComponent));
+
             expect(testHostComponent.inputValueComponent.mode).toEqual('update');
 
             expect(testHostComponent.inputValueComponent.form.valid).toBeFalsy();
@@ -234,6 +248,8 @@ describe('TextValueAsXMLComponent', () => {
 
             testHostFixture.detectChanges();
 
+            ckeditorDe = valueComponentDe.query(By.directive(TestCKEditorComponent));
+
             expect(testHostComponent.inputValueComponent.mode).toEqual('update');
 
             expect(testHostComponent.inputValueComponent.form.valid).toBeFalsy();
@@ -258,7 +274,7 @@ describe('TextValueAsXMLComponent', () => {
 
             const newXml = new ReadTextValueAsXml();
 
-            newXml.xml = '<?xml version="1.0" encoding="UTF-8"?><text><p>my updated text<p></text>';
+            newXml.xml = '<?xml version="1.0" encoding="UTF-8"?><text><p>my updated text</p></text>';
             newXml.mapping = 'http://rdfh.ch/standoff/mappings/StandardMapping';
 
             newXml.id = 'updatedId';
@@ -267,7 +283,7 @@ describe('TextValueAsXMLComponent', () => {
 
             testHostFixture.detectChanges();
 
-            expect(ckeditorDe.componentInstance.value).toEqual('<p>my updated text<p>');
+            expect(valueReadModeNativeElement.innerHTML).toEqual('<p>my updated text</p>');
 
             expect(testHostComponent.inputValueComponent.form.valid).toBeTruthy();
 
@@ -278,6 +294,8 @@ describe('TextValueAsXMLComponent', () => {
             testHostComponent.mode = 'update';
 
             testHostFixture.detectChanges();
+
+            ckeditorDe = valueComponentDe.query(By.directive(TestCKEditorComponent));
 
             // simulate input in ckeditor
             ckeditorDe.componentInstance.value = '<p>test <i>with</i> a lot of <i>markup</i></p>';
@@ -296,6 +314,8 @@ describe('TextValueAsXMLComponent', () => {
 
             testHostFixture.detectChanges();
 
+            ckeditorDe = valueComponentDe.query(By.directive(TestCKEditorComponent));
+
             // simulate input in ckeditor
             ckeditorDe.componentInstance.value = '<p>test with horizontal line <hr></hr></p>';
             ckeditorDe.componentInstance._handleInput();
@@ -313,6 +333,8 @@ describe('TextValueAsXMLComponent', () => {
 
             testHostFixture.detectChanges();
 
+            ckeditorDe = valueComponentDe.query(By.directive(TestCKEditorComponent));
+
             // simulate input in ckeditor
             ckeditorDe.componentInstance.value = '<p>test with <s>struck</s> word</p>';
             ckeditorDe.componentInstance._handleInput();
@@ -329,6 +351,8 @@ describe('TextValueAsXMLComponent', () => {
             testHostComponent.mode = 'update';
 
             testHostFixture.detectChanges();
+
+            ckeditorDe = valueComponentDe.query(By.directive(TestCKEditorComponent));
 
             // simulate input in ckeditor
             ckeditorDe.componentInstance.value = '<p><figure class="table"><table><tbody><tr><td>test</td><td>test</td></tr><tr><td>test</td><td>test</td></tr></tbody></table></figure></p>';

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.spec.ts
@@ -149,7 +149,7 @@ describe('TextValueAsXMLComponent', () => {
 
         });
 
-        it('should display an existing value', () => {
+        it('should display an existing value for the standard mapping as formatted text', () => {
 
             expect(testHostComponent.inputValueComponent.displayValue.xml).toEqual('<?xml version="1.0" encoding="UTF-8"?>\n<text><p>test with <strong>markup</strong></p></text>');
 
@@ -158,6 +158,31 @@ describe('TextValueAsXMLComponent', () => {
             expect(testHostComponent.inputValueComponent.mode).toEqual('read');
 
             expect(valueReadModeNativeElement.innerHTML).toEqual('\n<p>test with <strong>markup</strong></p>');
+
+        });
+
+        it('should display an existing value for a custom mapping as XML source code', () => {
+
+            const newXml = new ReadTextValueAsXml();
+
+            newXml.xml = '<?xml version="1.0" encoding="UTF-8"?><text><p>my updated text</p></text>';
+            newXml.mapping = 'http://rdfh.ch/standoff/mappings/customMapping';
+
+            newXml.id = 'id';
+
+            testHostComponent.displayInputVal = newXml;
+
+            testHostFixture.detectChanges();
+
+            valueReadModeDebugElement = valueComponentDe.query(By.css('.rm-value'));
+
+            valueReadModeNativeElement = valueReadModeDebugElement.nativeElement;
+
+            expect(valueReadModeNativeElement.innerText).toEqual(
+                '<?xml version="1.0" encoding="UTF-8"?><text><p>my updated text</p></text>');
+
+            // custom mappings are not supported by this component
+            expect(testHostComponent.inputValueComponent.form.valid).toBeFalsy();
 
         });
 

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
@@ -192,6 +192,11 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
         const openingTextTag = `<${textTag}>`;
         const closingTextTag = `</${textTag}>`;
 
+        // check if xml is a string
+        if (typeof xml !== 'string') {
+            return xml;
+        }
+
         if (fromKnora) {
             // CKEditor accepts tags from version 4
             // see 4 to 5 migration, see https://ckeditor.com/docs/ckeditor5/latest/builds/guides/migrate.html

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
@@ -3,7 +3,6 @@ import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { Constants, CreateTextValueAsXml, ReadTextValueAsXml, UpdateTextValueAsXml } from '@dasch-swiss/dsp-js';
 import * as Editor from 'ckeditor5-custom-build';
 import { Subscription } from 'rxjs';
-import { AppInitService } from '../../../../core/app-init.service';
 import { BaseValueComponent } from '../../base-value.component';
 import { ValueErrorStateMatcher } from '../../value-error-state-matcher';
 

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
@@ -1,12 +1,4 @@
-import {
-    Component,
-    Inject,
-    Input,
-    OnChanges,
-    OnDestroy,
-    OnInit,
-    SimpleChanges
-} from '@angular/core';
+import { Component, Inject, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { Constants, CreateTextValueAsXml, ReadTextValueAsXml, UpdateTextValueAsXml } from '@dasch-swiss/dsp-js';
 import * as Editor from 'ckeditor5-custom-build';
@@ -38,11 +30,24 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
     editor: Editor;
     editorConfig;
 
+    // XML conversion
+    xmlTransform = {
+        'http://rdfh.ch/standoff/mappings/StandardMapping': {
+            '<hr>': '<hr/>',
+            '</hr>': '',
+            '<s>': '<strike>',
+            '</s>': '</strike>',
+            '<i>': '<em>',
+            '</i>': '</em>',
+            '<figure class="table">': '',
+            '</figure>': ''
+        }
+    };
+
     // TODO: get this from config via AppInitService
     readonly resourceBasePath = 'http://rdfh.ch/';
 
-    constructor(private _appInitService: AppInitService,
-                @Inject(FormBuilder) private fb: FormBuilder) {
+    constructor(@Inject(FormBuilder) private fb: FormBuilder) {
         super();
     }
 
@@ -67,8 +72,7 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
 
         if (this.mapping !== undefined
             /*&& this.mapping === 'http://rdfh.ch/standoff/mappings/StandardMapping'*/
-            && this._appInitService.config['xmlTransform'] !== undefined
-            && this._appInitService.config['xmlTransform'][this.mapping] !== undefined) {
+            ) {
 
             this.editor = Editor;
 
@@ -209,10 +213,10 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
             xml = xml.replace(/&nbsp;/g, String.fromCharCode(160));
 
             // get XML transform config
-            const keys = Object.keys(this._appInitService.config['xmlTransform'][this.mapping]);
+            const keys = Object.keys(this.xmlTransform[this.mapping]);
             for (const key of keys) {
                 // replace tags defined in config
-                xml = xml.replace(new RegExp(key, 'g'), this._appInitService.config['xmlTransform'][this.mapping][key]);
+                xml = xml.replace(new RegExp(key, 'g'), this.xmlTransform[this.mapping][key]);
             }
 
             if (addXMLDocType) {

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
@@ -13,8 +13,9 @@ import { ValueErrorStateMatcher } from '../../value-error-state-matcher';
 })
 export class TextValueAsXMLComponent extends BaseValueComponent implements OnInit, OnChanges, OnDestroy {
 
+    readonly standardMapping = 'http://rdfh.ch/standoff/mappings/StandardMapping'; // TODO: define this somewhere else
+
     @Input() displayValue?: ReadTextValueAsXml;
-    @Input() mapping = 'http://rdfh.ch/standoff/mappings/StandardMapping'; // TODO: define this somewhere else
 
     valueFormControl: FormControl;
     commentFormControl: FormControl;
@@ -31,16 +32,14 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
 
     // XML conversion
     xmlTransform = {
-        'http://rdfh.ch/standoff/mappings/StandardMapping': {
-            '<hr>': '<hr/>',
-            '</hr>': '',
-            '<s>': '<strike>',
-            '</s>': '</strike>',
-            '<i>': '<em>',
-            '</i>': '</em>',
-            '<figure class="table">': '',
-            '</figure>': ''
-        }
+        '<hr>': '<hr/>',
+        '</hr>': '',
+        '<s>': '<strike>',
+        '</s>': '</strike>',
+        '<i>': '<em>',
+        '</i>': '</em>',
+        '<figure class="table">': '',
+        '</figure>': ''
     };
 
     // TODO: get this from config via AppInitService
@@ -60,7 +59,7 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
     getInitValue(): string | null {
 
         // check for standard mapping
-        if (this.displayValue !== undefined) {
+        if (this.displayValue !== undefined && this.displayValue.mapping === this.standardMapping) {
             return this._handleXML(this.displayValue.xml, true);
         } else {
             return null;
@@ -69,65 +68,61 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
 
     ngOnInit() {
 
-        if (this.mapping !== undefined
-            /*&& this.mapping === 'http://rdfh.ch/standoff/mappings/StandardMapping'*/
-            ) {
+        this.editor = Editor;
 
-            this.editor = Editor;
-
-            this.editorConfig = {
-                entities: false,
-                link: {
-                    addTargetToExternalLinks: false,
-                    decorators: {
-                        isInternal: {
-                            // label: 'internal link to a Knora resource',
-                            mode: 'automatic', // automatic requires callback -> but the callback is async and the user could save the text before the check ...
-                            callback: url => { /*console.log(url, url.startsWith( 'http://rdfh.ch/' ));*/
-                                return !!url && url.startsWith(this.resourceBasePath);
-                            },
-                            attributes: {
-                                class: Constants.SalsahLink
-                            }
+        this.editorConfig = {
+            entities: false,
+            link: {
+                addTargetToExternalLinks: false,
+                decorators: {
+                    isInternal: {
+                        // label: 'internal link to a Knora resource',
+                        mode: 'automatic', // automatic requires callback -> but the callback is async and the user could save the text before the check ...
+                        callback: url => { /*console.log(url, url.startsWith( 'http://rdfh.ch/' ));*/
+                            return !!url && url.startsWith(this.resourceBasePath);
+                        },
+                        attributes: {
+                            class: Constants.SalsahLink
                         }
                     }
-                },
-                toolbar: ['heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'underline', 'strikethrough', 'subscript', 'superscript', 'horizontalline', 'insertTable', 'code', 'codeBlock', 'removeformat', 'redo', 'undo'],
-                heading: {
-                    options: [
-                        {model: 'heading1', view: 'h1', title: 'Heading 1'},
-                        {model: 'heading2', view: 'h2', title: 'Heading 2'},
-                        {model: 'heading3', view: 'h3', title: 'Heading 3'},
-                        {model: 'heading4', view: 'h4', title: 'Heading 4'},
-                        {model: 'heading5', view: 'h5', title: 'Heading 5'},
-                        {model: 'heading6', view: 'h6', title: 'Heading 6'},
-                    ]
-                },
-                codeBlock: {
-                    languages: [
-                        {language: 'plaintext', label: 'Plain text', class: ''}
-                    ]
                 }
-            };
+            },
+            toolbar: ['heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'underline', 'strikethrough', 'subscript', 'superscript', 'horizontalline', 'insertTable', 'code', 'codeBlock', 'removeformat', 'redo', 'undo'],
+            heading: {
+                options: [
+                    {model: 'heading1', view: 'h1', title: 'Heading 1'},
+                    {model: 'heading2', view: 'h2', title: 'Heading 2'},
+                    {model: 'heading3', view: 'h3', title: 'Heading 3'},
+                    {model: 'heading4', view: 'h4', title: 'Heading 4'},
+                    {model: 'heading5', view: 'h5', title: 'Heading 5'},
+                    {model: 'heading6', view: 'h6', title: 'Heading 6'},
+                ]
+            },
+            codeBlock: {
+                languages: [
+                    {language: 'plaintext', label: 'Plain text', class: ''}
+                ]
+            }
+        };
 
-            // initialize form control elements
-            this.valueFormControl = new FormControl(null);
+        // initialize form control elements
+        this.valueFormControl = new FormControl(null);
 
-            this.commentFormControl = new FormControl(null);
+        this.commentFormControl = new FormControl(null);
 
-            this.valueChangesSubscription = this.commentFormControl.valueChanges.subscribe(
-                data => {
-                    this.valueFormControl.updateValueAndValidity();
-                }
-            );
+        this.valueChangesSubscription = this.commentFormControl.valueChanges.subscribe(
+            data => {
+                this.valueFormControl.updateValueAndValidity();
+            }
+        );
 
-            this.form = this.fb.group({
-                xmlValue: this.valueFormControl,
-                comment: this.commentFormControl
-            });
+        this.form = this.fb.group({
+            xmlValue: this.valueFormControl,
+            comment: this.commentFormControl
+        });
 
-            this.resetFormControl();
-        }
+        this.resetFormControl();
+
     }
 
     ngOnChanges(changes: SimpleChanges): void {
@@ -151,7 +146,7 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
         const newTextValue = new CreateTextValueAsXml();
 
         newTextValue.xml = this._handleXML(this.valueFormControl.value, false);
-        newTextValue.mapping = this.mapping;
+        newTextValue.mapping = this.standardMapping;
 
         if (this.commentFormControl.value !== null && this.commentFormControl.value !== '') {
             newTextValue.valueHasComment = this.commentFormControl.value;
@@ -172,7 +167,7 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
         updatedTextValue.id = this.displayValue.id;
 
         updatedTextValue.xml = this._handleXML(this.valueFormControl.value, false);
-        updatedTextValue.mapping = this.mapping;
+        updatedTextValue.mapping = this.standardMapping;
 
         if (this.commentFormControl.value !== null && this.commentFormControl.value !== '') {
             updatedTextValue.valueHasComment = this.commentFormControl.value;
@@ -212,10 +207,10 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
             xml = xml.replace(/&nbsp;/g, String.fromCharCode(160));
 
             // get XML transform config
-            const keys = Object.keys(this.xmlTransform[this.mapping]);
+            const keys = Object.keys(this.xmlTransform);
             for (const key of keys) {
                 // replace tags defined in config
-                xml = xml.replace(new RegExp(key, 'g'), this.xmlTransform[this.mapping][key]);
+                xml = xml.replace(new RegExp(key, 'g'), this.xmlTransform[key]);
             }
 
             if (addXMLDocType) {

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
@@ -44,7 +44,11 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
         if (this.displayValue !== undefined) {
 
             // strip the doctype and text tag
-            return this._handleXML(this.displayValue.xml, true);
+            console.log('text before conversion: ', this.displayValue.xml);
+            const converted = this._handleXML(this.displayValue.xml, true);
+            console.log('text after conversion: ', converted);
+
+            return converted;
         } else {
             return null;
         }
@@ -53,6 +57,7 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
     ngOnInit() {
 
         if (this.mapping !== undefined
+            && this.mapping === 'http://rdfh.ch/standoff/mappings/StandardMapping'
             && this._appInitService.config['xmlTransform'] !== undefined
             && this._appInitService.config['xmlTransform'][this.mapping] !== undefined) {
 
@@ -94,7 +99,7 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
             };
 
             // initialize form control elements
-            this.valueFormControl = new FormControl({value: null, disabled: this.mode === 'read'});
+            this.valueFormControl = new FormControl(null);
 
             this.commentFormControl = new FormControl(null);
 
@@ -185,11 +190,14 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
         const closingTextTag = `</${textTag}>`;
 
         if (fromKnora) {
-            // CKEditor accepts tags from version 4, no conversion needed
+            // CKEditor accepts tags from version 4
             // see 4 to 5 migration, see https://ckeditor.com/docs/ckeditor5/latest/builds/guides/migrate.html
+            // CKEditor 5 uses <i> for italics so we need to convert the <em> tags from knora to <i> so that the validator works
             return xml.replace(doctype, '')
                 .replace(openingTextTag, '')
-                .replace(closingTextTag, '');
+                .replace(closingTextTag, '')
+                .replace('<em>', '<i>')
+                .replace('</em>', '</i>');
         } else {
 
             // replace &nbsp; entity

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
@@ -1,4 +1,12 @@
-import { Component, Inject, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import {
+    Component,
+    Inject,
+    Input,
+    OnChanges,
+    OnDestroy,
+    OnInit,
+    SimpleChanges
+} from '@angular/core';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { Constants, CreateTextValueAsXml, ReadTextValueAsXml, UpdateTextValueAsXml } from '@dasch-swiss/dsp-js';
 import * as Editor from 'ckeditor5-custom-build';
@@ -38,17 +46,20 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
         super();
     }
 
+    standardValueComparisonFunc(initValue: any, curValue: any): boolean {
+        const initValueTrimmed = typeof initValue === 'string' ? initValue.trim() : initValue;
+        const curValueTrimmed = typeof curValue === 'string' ? curValue.trim() : curValue;
+
+        // TODO: convert curValueTrimmed to Knora XML schema
+
+        return initValueTrimmed === curValueTrimmed;
+    }
+
     getInitValue(): string | null {
 
         // check for standard mapping
         if (this.displayValue !== undefined) {
-
-            // strip the doctype and text tag
-            console.log('text before conversion: ', this.displayValue.xml);
-            const converted = this._handleXML(this.displayValue.xml, true);
-            console.log('text after conversion: ', converted);
-
-            return converted;
+            return this._handleXML(this.displayValue.xml, true);
         } else {
             return null;
         }
@@ -57,7 +68,7 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
     ngOnInit() {
 
         if (this.mapping !== undefined
-            && this.mapping === 'http://rdfh.ch/standoff/mappings/StandardMapping'
+            /*&& this.mapping === 'http://rdfh.ch/standoff/mappings/StandardMapping'*/
             && this._appInitService.config['xmlTransform'] !== undefined
             && this._appInitService.config['xmlTransform'][this.mapping] !== undefined) {
 
@@ -72,7 +83,7 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
                             // label: 'internal link to a Knora resource',
                             mode: 'automatic', // automatic requires callback -> but the callback is async and the user could save the text before the check ...
                             callback: url => { /*console.log(url, url.startsWith( 'http://rdfh.ch/' ));*/
-                                return url.startsWith(this.resourceBasePath);
+                                return !!url && url.startsWith(this.resourceBasePath);
                             },
                             attributes: {
                                 class: Constants.SalsahLink
@@ -123,13 +134,6 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
         // resets values and validators in form controls when input displayValue or mode changes
         // at the first call of ngOnChanges, form control elements are not initialized yet
         this.resetFormControl();
-
-        // mode is controlled via the FormControl
-        if (this.valueFormControl !== undefined && this.mode === 'read') {
-            this.valueFormControl.disable();
-        } else if (this.valueFormControl !== undefined) {
-            this.valueFormControl.enable();
-        }
 
     }
 
@@ -196,8 +200,6 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
             return xml.replace(doctype, '')
                 .replace(openingTextTag, '')
                 .replace(closingTextTag, '')
-                .replace('<em>', '<i>')
-                .replace('</em>', '</i>');
         } else {
 
             // replace &nbsp; entity

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
@@ -50,7 +50,7 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
         const initValueTrimmed = typeof initValue === 'string' ? initValue.trim() : initValue;
         const curValueTrimmed = typeof curValue === 'string' ? curValue.trim() : curValue;
 
-        return initValueTrimmed === this._handleXML(curValueTrimmed, false);
+        return initValueTrimmed === this._handleXML(curValueTrimmed, false, false);
     }
 
     getInitValue(): string | null {
@@ -183,8 +183,9 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
      *
      * @param xml xml to be processed.
      * @param fromKnora true if xml is received from Knora.
+     * @param addXMLDocType whether to add the doctype to the XML.
      */
-    private _handleXML(xml: string, fromKnora: boolean) {
+    private _handleXML(xml: string, fromKnora: boolean, addXMLDocType = true) {
 
         const doctype = '<?xml version="1.0" encoding="UTF-8"?>';
         const textTag = 'text';
@@ -209,7 +210,11 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
                 xml = xml.replace(new RegExp(key, 'g'), this._appInitService.config['xmlTransform'][this.mapping][key]);
             }
 
-            return doctype + openingTextTag + xml + closingTextTag;
+            if (addXMLDocType) {
+                return doctype + openingTextTag + xml + closingTextTag;
+            } else {
+                return xml;
+            }
         }
 
     }

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
@@ -50,9 +50,7 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
         const initValueTrimmed = typeof initValue === 'string' ? initValue.trim() : initValue;
         const curValueTrimmed = typeof curValue === 'string' ? curValue.trim() : curValue;
 
-        // TODO: convert curValueTrimmed to Knora XML schema
-
-        return initValueTrimmed === curValueTrimmed;
+        return initValueTrimmed === this._handleXML(curValueTrimmed, false);
     }
 
     getInitValue(): string | null {
@@ -196,10 +194,9 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
         if (fromKnora) {
             // CKEditor accepts tags from version 4
             // see 4 to 5 migration, see https://ckeditor.com/docs/ckeditor5/latest/builds/guides/migrate.html
-            // CKEditor 5 uses <i> for italics so we need to convert the <em> tags from knora to <i> so that the validator works
             return xml.replace(doctype, '')
                 .replace(openingTextTag, '')
-                .replace(closingTextTag, '')
+                .replace(closingTextTag, '');
         } else {
 
             // replace &nbsp; entity

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.spec.ts
@@ -219,7 +219,7 @@ describe('PropertyViewComponent', () => {
 
         it('should show an add button under each property that has a value component and value and appropriate cardinality', () => {
             const addButtons = propertyViewComponentDe.queryAll(By.css('button.create'));
-            expect(addButtons.length).toEqual(13);
+            expect(addButtons.length).toEqual(14);
 
         });
 
@@ -231,8 +231,8 @@ describe('PropertyViewComponent', () => {
 
             let addButtons = propertyViewComponentDe.queryAll(By.css('button.create'));
 
-            // current amount of buttons should equal 18 because the boolean property shouldn't have an add button if it has a value
-            expect(addButtons.length).toEqual(18);
+            // current amount of buttons should equal 19 because the boolean property shouldn't have an add button if it has a value
+            expect(addButtons.length).toEqual(19);
 
             // remove value from the boolean property
             testHostComponent.propArray[9].values = [];
@@ -241,7 +241,7 @@ describe('PropertyViewComponent', () => {
 
             // now the boolean property should have an add button so the amount of add buttons on the page should increase by 1
             addButtons = propertyViewComponentDe.queryAll(By.css('button.create'));
-            expect(addButtons.length).toEqual(19);
+            expect(addButtons.length).toEqual(20);
 
         });
 
@@ -258,7 +258,7 @@ describe('PropertyViewComponent', () => {
             const addButtons = propertyViewComponentDe.queryAll(By.css('button.create'));
 
             // the add button for the property with the open add value form is hidden
-            expect(addButtons.length).toEqual(12);
+            expect(addButtons.length).toEqual(13);
 
             expect(propertyViewComponentDe.query(By.css('.add-value'))).toBeDefined();
 

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.ts
@@ -59,6 +59,7 @@ export class PropertyViewComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         if (this.parentResource) {
+            console.log(this.parentResource);
             // get user permissions
             const allPermissions = PermissionUtil.allUserPermissions(
                 this.parentResource.userHasPermission as 'RV' | 'V' | 'M' | 'D' | 'CR'
@@ -104,10 +105,10 @@ export class PropertyViewComponent implements OnInit, OnDestroy {
      */
     addValueIsAllowed(prop: PropertyInfoValues): boolean {
         // temporary until CkEditor is integrated
-        const guiElement = (prop.propDef as ResourcePropertyDefinition).guiElement;
-        if (guiElement === 'http://api.knora.org/ontology/salsah-gui/v2#Richtext') {
-            return false;
-        }
+        // const guiElement = (prop.propDef as ResourcePropertyDefinition).guiElement;
+        // if (guiElement === 'http://api.knora.org/ontology/salsah-gui/v2#Richtext') {
+        //     return false;
+        // }
 
         const isAllowed = CardinalityUtil.createValueForPropertyAllowed(
             prop.propDef.id, prop.values.length, this.parentResource.entityInfo.classes[this.parentResource.type]);

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.ts
@@ -59,7 +59,6 @@ export class PropertyViewComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         if (this.parentResource) {
-            console.log(this.parentResource);
             // get user permissions
             const allPermissions = PermissionUtil.allUserPermissions(
                 this.parentResource.userHasPermission as 'RV' | 'V' | 'M' | 'D' | 'CR'

--- a/src/config/config.dev.json
+++ b/src/config/config.dev.json
@@ -4,17 +4,5 @@
   "apiPort": 3333,
   "apiPath": "",
   "jsonWebToken": "",
-  "logErrors": true,
-  "xmlTransform": {
-    "http://rdfh.ch/standoff/mappings/StandardMapping": {
-      "<hr>": "<hr/>",
-      "</hr>": "",
-      "<s>": "<strike>",
-      "</s>": "</strike>",
-      "<i>": "<em>",
-      "</i>": "</em>",
-      "<figure class=\"table\">": "",
-      "</figure>": ""
-    }
-  }
+  "logErrors": true
 }

--- a/src/config/config.prod.json
+++ b/src/config/config.prod.json
@@ -4,17 +4,5 @@
   "apiPort": 3333,
   "apiPath": "",
   "jsonWebToken": "",
-  "logErrors": false,
-  "xmlTransform": {
-    "http://rdfh.ch/standoff/mappings/StandardMapping": {
-      "<hr>": "<hr/>",
-      "</hr>": "",
-      "<s>": "<strike>",
-      "</s>": "</strike>",
-      "<i>": "<em>",
-      "</i>": "</em>",
-      "<figure class=\"table\">": "",
-      "</figure>": ""
-    }
-  }
+  "logErrors": false
 }


### PR DESCRIPTION
resolves [DSP-682](https://dasch.myjetbrains.com/youtrack/issue/DSP-682)

`ValueTypeService.isReadOnly` has a a second required param now: `isReadOnly(valueTypeOrClass: string, value: ReadValue): boolean`
