### PR TITLE
DSP-779 Display error messages directly and not only in console

### DIFF
--- a/projects/dsp-ui/src/lib/action/components/login-form/login-form.component.html
+++ b/projects/dsp-ui/src/lib/action/components/login-form/login-form.component.html
@@ -50,11 +50,12 @@
         <br><br>
 
         <!-- Error message as an answer from knora api request -->
-        <p class="full-width login-error" *ngIf="errorMessage">
-            {{loginErrorServer ? formLabel.error.server : formLabel.error.failed}}
-        </p>
+        <p *ngIf="loginFailed">{{formLabel.error.failed}}</p>
     </form>
 </div>
+
+<!-- api server error -->
+<dsp-message *ngIf="loginErrorServer" [apiError]="errorMessage"></dsp-message>
 
 <!-- a user is already logged in; show who it is and a logout button -->
 <div class="logout-container" *ngIf="session">

--- a/projects/dsp-ui/src/lib/action/components/login-form/login-form.component.html
+++ b/projects/dsp-ui/src/lib/action/components/login-form/login-form.component.html
@@ -50,7 +50,7 @@
         <br><br>
 
         <!-- Error message as an answer from knora api request -->
-        <p *ngIf="loginFailed">{{formLabel.error.failed}}</p>
+        <p class="login-error" *ngIf="loginFailed">{{formLabel.error.failed}}</p>
     </form>
 </div>
 

--- a/projects/dsp-ui/src/lib/action/components/login-form/login-form.component.ts
+++ b/projects/dsp-ui/src/lib/action/components/login-form/login-form.component.ts
@@ -78,7 +78,7 @@ export class LoginFormComponent implements OnInit {
         forgot_pw: 'Forgot password?',
         error: {
             failed: 'Password or username is wrong',
-            server: 'There\'s an error with the server connection. Try it again later or inform the DaSCH team.'
+            server: 'An error has occurred when connecting to the server. Try again later or contact the DaSCH support.'
         }
     };
 
@@ -159,7 +159,7 @@ export class LoginFormComponent implements OnInit {
                 // error handling
                 this.loginErrorUser = (error.status === 404);
                 this.loginErrorPw = (error.status === 401);
-                this.loginErrorServer = (error.status === 0);
+                this.loginErrorServer = (error.status === 0 || error.status >= 500 && error.status < 600);
 
                 this.loginSuccess.emit(false);
                 this.errorMessage = error;

--- a/projects/dsp-ui/src/lib/action/components/login-form/login-form.component.ts
+++ b/projects/dsp-ui/src/lib/action/components/login-form/login-form.component.ts
@@ -61,8 +61,7 @@ export class LoginFormComponent implements OnInit {
     errorMessage: ApiResponseError;
 
     // specific error messages
-    loginErrorUser = false;
-    loginErrorPw = false;
+    loginFailed = false;
     loginErrorServer = false;
 
     // labels for the login form
@@ -157,15 +156,13 @@ export class LoginFormComponent implements OnInit {
             },
             (error: ApiResponseError) => {
                 // error handling
-                this.loginErrorUser = (error.status === 404);
-                this.loginErrorPw = (error.status === 401);
+                this.loginFailed = (error.status === 401 || error.status === 404);
                 this.loginErrorServer = (error.status === 0 || error.status >= 500 && error.status < 600);
 
                 this.loginSuccess.emit(false);
                 this.errorMessage = error;
 
                 this.loading = false;
-                // TODO: update error handling similar to the old method (see commented code below)
             }
         );
     }
@@ -190,7 +187,7 @@ export class LoginFormComponent implements OnInit {
             },
             (error: ApiResponseError) => {
                 console.error(error);
-                this.loginSuccess.emit(false);
+                this.logoutSuccess.emit(false);
                 this.loading = false;
             }
         );

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.html
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.html
@@ -25,7 +25,7 @@
 
     </mat-card-content>
 
-    <mat-card-footer *ngIf="(size === 'large')" class="message-footnote" [innerHtml]="message?.footnote"></mat-card-footer>
+    <mat-card-footer *ngIf="(size === 'long')" class="message-footnote" [innerHtml]="message?.footnote"></mat-card-footer>
 
 </mat-card>
 

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.html
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.html
@@ -25,11 +25,11 @@
 
     </mat-card-content>
 
-    <mat-card-footer *ngIf="!medium" class="message-footnote" [innerHtml]="message?.footnote"></mat-card-footer>
+    <mat-card-footer *ngIf="(size === 'large')" class="message-footnote" [innerHtml]="message?.footnote"></mat-card-footer>
 
 </mat-card>
 
-<mat-card *ngIf="short && !disable" class="fix-width dsp-short-message" [ngClass]="'dsp-' + message?.type"
+<mat-card *ngIf="(size === 'short') && !disable" class="fix-width dsp-short-message" [ngClass]="'dsp-' + message?.type"
           (click)="closeMessage()">
 
     <div class="dsp-panel">

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.html
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.html
@@ -40,9 +40,9 @@
             Please come back in a few minutes and try to <a class="link bolder" (click)="reload()">reload the page</a>.
         </p>
 
-        <!-- Action: Contact DSP support -->
+        <!-- Action: Contact DaSCH/DSP support -->
         <a mat-button class="action" href="https://docs.dasch.swiss/community/faq" target="_blank">
-            <mat-icon>mail_outline</mat-icon> Contact DSP support
+            <mat-icon>mail_outline</mat-icon> Contact the support team
         </a>
     </mat-card-footer>
 

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.html
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.html
@@ -1,4 +1,4 @@
-<mat-card *ngIf="!short" class="fix-width dsp-message" [ngClass]="'dsp-' + message?.type">
+<mat-card *ngIf="(size !== 'short')" class="fix-width dsp-message" [ngClass]="'dsp-' + message?.type">
 
     <mat-card-subtitle class="message-subtitle">
         <span class="left">{{message?.type | uppercase }} {{message?.status}} | {{message?.statusMsg}}</span>

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.html
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.html
@@ -15,6 +15,12 @@
             </mat-list-item>
         </mat-list>
 
+        <mat-list *ngIf="apiError">
+            <mat-list-item>
+                <p mat-line>{{apiError.error.toString()}}</p>
+            </mat-list-item>
+        </mat-list>
+
         <mat-list *ngIf="showLinks">
             <p>{{links.title}}</p>
             <mat-list-item *ngFor="let item of links.list" class="link" (click)="goToLocation(item.route)">
@@ -25,7 +31,20 @@
 
     </mat-card-content>
 
-    <mat-card-footer *ngIf="(size === 'long')" class="message-footnote" [innerHtml]="message?.footnote"></mat-card-footer>
+    <mat-card-footer *ngIf="(size === 'long')" class="message-footnote">
+        <!-- Specific message from @Input -->
+        <p *ngIf="message.footnote">{{message.footnote}}</p>
+
+        <!-- Else: Default message -->
+        <p *ngIf="!message.footnote && !showLinks">
+            Please come back in a few minutes and try to <a class="link bolder" (click)="reload()">reload the page</a>.
+        </p>
+
+        <!-- Action: Contact DSP support -->
+        <a mat-button class="action" href="https://docs.dasch.swiss/community/faq" target="_blank">
+            <mat-icon>mail_outline</mat-icon> Contact DSP support
+        </a>
+    </mat-card-footer>
 
 </mat-card>
 

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.scss
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.scss
@@ -73,6 +73,15 @@ $warn: rgb(244, 67, 54);
 
   .message-footnote {
     padding: 24px;
+
+    .bolder {
+      font-weight: bolder;
+    }
+
+    .action {
+      margin: 48px auto 0 auto;
+      display: table;
+    }
   }
 }
 

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.spec.ts
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.spec.ts
@@ -13,7 +13,7 @@ import { DspMessageData, MessageComponent } from './message.component';
  * Test host component to simulate parent component.
  */
 @Component({
-    template: `<dsp-message #message [message]="shortMessage" [size]="'short'"></dsp-message>`
+    template: `<dsp-message #message [message]="shortMessage" [size]="size"></dsp-message>`
 })
 class ShortMessageTestHostComponent implements OnInit {
 
@@ -39,7 +39,7 @@ class ShortMessageTestHostComponent implements OnInit {
  * Test host component to simulate parent component.
  */
 @Component({
-    template: `<dsp-message #message [message]="errorMessage" [size]="'short'"></dsp-message>`
+    template: `<dsp-message #message [message]="errorMessage"></dsp-message>`
 })
 class LongMessageTestHostComponent implements OnInit {
 
@@ -52,8 +52,6 @@ class LongMessageTestHostComponent implements OnInit {
         error: 'error message'
     };
 
-    size = 'short';
-
     constructor() {
     }
 
@@ -64,7 +62,7 @@ class LongMessageTestHostComponent implements OnInit {
  * Test host component to simulate parent component.
  */
 @Component({
-    template: `<dsp-message #message [message]="shortMessage" [size]="'short'" [duration]="2000"></dsp-message>`
+    template: `<dsp-message #message [message]="shortMessage" [size]="size" [duration]="2000"></dsp-message>`
 })
 class ShortMessageWithDurationTestHostComponent implements OnInit {
 

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.spec.ts
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.spec.ts
@@ -13,7 +13,7 @@ import { DspMessageData, MessageComponent } from './message.component';
  * Test host component to simulate parent component.
  */
 @Component({
-    template: `<dsp-message #message [message]="shortMessage" [short]="short"></dsp-message>`
+    template: `<dsp-message #message [message]="shortMessage" [size]="'short'"></dsp-message>`
 })
 class ShortMessageTestHostComponent implements OnInit {
 
@@ -27,7 +27,7 @@ class ShortMessageTestHostComponent implements OnInit {
         footnote: 'Close it'
     };
 
-    short = true;
+    size = 'short';
 
     constructor() {
     }
@@ -39,7 +39,7 @@ class ShortMessageTestHostComponent implements OnInit {
  * Test host component to simulate parent component.
  */
 @Component({
-    template: `<dsp-message #message [message]="errorMessage" [short]="short"></dsp-message>`
+    template: `<dsp-message #message [message]="errorMessage" [size]="'short'"></dsp-message>`
 })
 class LongMessageTestHostComponent implements OnInit {
 
@@ -52,7 +52,7 @@ class LongMessageTestHostComponent implements OnInit {
         error: 'error message'
     };
 
-    short = false;
+    size = 'short';
 
     constructor() {
     }
@@ -64,7 +64,7 @@ class LongMessageTestHostComponent implements OnInit {
  * Test host component to simulate parent component.
  */
 @Component({
-    template: `<dsp-message #message [message]="shortMessage" [short]="short" [duration]="2000"></dsp-message>`
+    template: `<dsp-message #message [message]="shortMessage" [size]="'short'" [duration]="2000"></dsp-message>`
 })
 class ShortMessageWithDurationTestHostComponent implements OnInit {
 
@@ -78,7 +78,7 @@ class ShortMessageWithDurationTestHostComponent implements OnInit {
         footnote: 'Close it'
     };
 
-    short = true;
+    size = 'short';
 
     constructor() {
     }

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.ts
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.ts
@@ -31,9 +31,9 @@ export class tmpApiResponseError {
 }
 
 @Component({
-  selector: 'dsp-message',
-  templateUrl: './message.component.html',
-  styleUrls: ['./message.component.scss']
+    selector: 'dsp-message',
+    templateUrl: './message.component.html',
+    styleUrls: ['./message.component.scss']
 })
 export class MessageComponent implements OnInit {
 
@@ -41,13 +41,13 @@ export class MessageComponent implements OnInit {
      * Message type: DspMessageData
      *
      * @param message This type needs at least a status number (0-599).
-     * In this case, or if type is ApiServiceError, it takes the default status messages
+     * In this case, or if type is ApiResponseError, it takes the default status messages
      * from the list of HTTP status codes (https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
      */
     @Input() message: DspMessageData = new DspMessageData();
 
     /**
-     * Message type: ApiServiceError
+     * Message type: ApiResponseError
      * @param apiError
      */
     @Input() apiError?: ApiResponseError;
@@ -131,7 +131,7 @@ export class MessageComponent implements OnInit {
     ngOnInit() {
         // temporary solution as long we have to support the deprecated inputs "short" and "medium"
         if (this.short || this.medium) {
-            this.size = (this.short ? 'short' :  'medium')
+            this.size = (this.short ? 'short' : 'medium')
         }
 
 

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.ts
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.ts
@@ -53,10 +53,10 @@ export class MessageComponent implements OnInit {
     @Input() apiError?: ApiResponseError;
 
     /**
-     * Size of the message: large, medium or short?
-     * @param size Default size is 'large'
+     * Size of the message: long, medium or short?
+     * @param size Default size is 'long'
      */
-    @Input() size: 'short' | 'medium' | 'large' = 'large';
+    @Input() size: 'short' | 'medium' | 'long' = 'long';
 
     /**
      * @deprecated
@@ -210,7 +210,7 @@ export class MessageComponent implements OnInit {
                     msg.footnote !== undefined
                         ? msg.footnote
                         : this.footnote.text + ' ' + this.footnote.team.dasch;
-                this.showLinks = (this.size === 'large');
+                this.showLinks = (this.size === 'long');
                 break;
             case s >= 500 && s < 600:
                 // the message is a server side (api) error

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.ts
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.ts
@@ -19,17 +19,6 @@ export class DspMessageData {
     url?: string;
 }
 
-export class tmpApiResponseError {
-    status: number;
-    message: string;
-    name: string;
-    request: any;
-    response: any;
-    responseType: string;
-    xhr: XMLHttpRequest
-
-}
-
 @Component({
     selector: 'dsp-message',
     templateUrl: './message.component.html',

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.ts
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.ts
@@ -114,10 +114,10 @@ export class MessageComponent implements OnInit {
     };
 
     footnote: any = {
-        text: 'If you think this is a mistake, please',
+        text: 'Please try again later.',
         team: {
             dasch:
-                '<a href=\'https://docs.dasch.swiss/community/\' target=\'_blank\'> contact the DaSCH support.</a>'
+                '<a href=\'https://docs.dasch.swiss/community/\' target=\'_blank\'>Contact the DaSCH support.</a>'
         }
     };
 
@@ -129,6 +129,12 @@ export class MessageComponent implements OnInit {
     ) { }
 
     ngOnInit() {
+        // temporary solution as long we have to support the deprecated inputs "short" and "medium"
+        if (this.short || this.medium) {
+            this.size = (this.short ? 'short' :  'medium')
+        }
+
+
         if (this.apiError) {
             this.message.status = this.apiError.status;
         }

--- a/projects/dsp-ui/src/lib/action/components/message/message.component.ts
+++ b/projects/dsp-ui/src/lib/action/components/message/message.component.ts
@@ -113,14 +113,6 @@ export class MessageComponent implements OnInit {
         ]
     };
 
-    footnote: any = {
-        text: 'Please try again later.',
-        team: {
-            dasch:
-                '<a href=\'https://docs.dasch.swiss/community/\' target=\'_blank\'>Contact the DaSCH support.</a>'
-        }
-    };
-
     constructor(
         private _router: Router,
         private _location: Location,
@@ -206,10 +198,6 @@ export class MessageComponent implements OnInit {
                     msg.statusText !== undefined
                         ? msg.statusText
                         : this.statusMsg[s].description;
-                tmpMsg.footnote =
-                    msg.footnote !== undefined
-                        ? msg.footnote
-                        : this.footnote.text + ' ' + this.footnote.team.dasch;
                 this.showLinks = (this.size === 'long');
                 break;
             case s >= 500 && s < 600:
@@ -224,8 +212,6 @@ export class MessageComponent implements OnInit {
                     msg.statusText !== undefined
                         ? msg.statusText
                         : this.statusMsg[s].description;
-                tmpMsg.footnote =
-                    this.footnote.text + ' ' + this.footnote.team.dasch;
                 this.showLinks = false;
                 break;
             default:
@@ -246,6 +232,10 @@ export class MessageComponent implements OnInit {
 
     closeMessage() {
         this.disable = !this.disable;
+    }
+
+    reload() {
+        window.location.reload();
     }
 
 }

--- a/projects/dsp-ui/src/lib/search/advanced-search/advanced-search.component.html
+++ b/projects/dsp-ui/src/lib/search/advanced-search/advanced-search.component.html
@@ -1,4 +1,4 @@
-<form [formGroup]="form" (ngSubmit)="submit()" class="dsp-form-content">
+<form *ngIf="!errorMessage" [formGroup]="form" (ngSubmit)="submit()" class="dsp-form-content">
 
     <div *ngIf="ontologiesMetadata?.ontologies.length > 0">
         <dsp-select-ontology [formGroup]="form" [ontologiesMetadata]="ontologiesMetadata"
@@ -46,3 +46,5 @@
     </div>
 
 </form>
+
+<dsp-message *ngIf="errorMessage" [apiError]="errorMessage" [size]="'medium'"></dsp-message>

--- a/projects/dsp-ui/src/lib/search/advanced-search/advanced-search.component.ts
+++ b/projects/dsp-ui/src/lib/search/advanced-search/advanced-search.component.ts
@@ -69,6 +69,8 @@ export class AdvancedSearchComponent implements OnInit, OnDestroy {
 
     formChangesSubscription: Subscription;
 
+    errorMessage: ApiResponseError;
+
     // reference to the component that controls the resource class selection
     @ViewChild('resourceClass') resourceClassComponent: SelectResourceClassComponent;
 
@@ -133,7 +135,7 @@ export class AdvancedSearchComponent implements OnInit, OnDestroy {
                 this.ontologiesMetadata = response;
             },
             (error: ApiResponseError) => {
-                console.error(error);
+                this.errorMessage = error;
             });
     }
 

--- a/projects/dsp-ui/src/lib/search/search.module.ts
+++ b/projects/dsp-ui/src/lib/search/search.module.ts
@@ -34,6 +34,7 @@ import { SearchListValueComponent } from './advanced-search/select-property/spec
 import { SearchDisplayListComponent } from './advanced-search/select-property/specify-property-value/search-list-value/search-display-list/search-display-list.component';
 import { SearchTextValueComponent } from './advanced-search/select-property/specify-property-value/search-text-value/search-text-value.component';
 import { SearchUriValueComponent } from './advanced-search/select-property/specify-property-value/search-uri-value/search-uri-value.component';
+import { DspActionModule } from '../action';
 
 
 
@@ -75,6 +76,7 @@ import { SearchUriValueComponent } from './advanced-search/select-property/speci
         MatInputModule,
         MatDatepickerModule,
         MatAutocompleteModule,
+        DspActionModule,
         DspViewerModule,
         TextFieldModule
     ],

--- a/projects/dsp-ui/src/lib/viewer/views/list-view/list-view.component.html
+++ b/projects/dsp-ui/src/lib/viewer/views/list-view/list-view.component.html
@@ -33,11 +33,16 @@
     </div>
 
     <!-- In case of 0 result -->
-    <div class="list-view zero" *ngIf="!loading && numberOfAllResults === 0">
+    <div class="list-view" *ngIf="!loading && numberOfAllResults === 0">
         <dsp-message
             [message]="{status: 404, statusMsg: 'No results', statusText: 'Sorry, but we couldn\'t find any results matching your search'}"
             [medium]="true">
         </dsp-message>
+    </div>
+
+    <!-- In case of server error -->
+    <div class="list-view server-error" *ngIf="errorMessage">
+        <dsp-message [apiError]="errorMessage"></dsp-message>
     </div>
 
 </div>

--- a/projects/dsp-ui/src/lib/viewer/views/list-view/list-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/list-view/list-view.component.ts
@@ -98,7 +98,6 @@ export class ListViewComponent implements OnChanges {
                     },
                     (error: ApiResponseError) => {
                         this.errorMessage = error;
-                        console.error(error);
                     }
                 );
             }
@@ -111,7 +110,6 @@ export class ListViewComponent implements OnChanges {
                 },
                 (error: ApiResponseError) => {
                     this.errorMessage = error;
-                    console.error(error);
                     this.loading = false;
                 }
             );
@@ -128,7 +126,6 @@ export class ListViewComponent implements OnChanges {
                     },
                     (error: ApiResponseError) => {
                         this.errorMessage = error;
-                        console.error(error);
                     }
                 );
             }
@@ -144,7 +141,6 @@ export class ListViewComponent implements OnChanges {
                     },
                     (error: ApiResponseError) => {
                         this.errorMessage = error;
-                        console.error(error);
                         this.loading = false;
                     }
                 );

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.html
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.html
@@ -1,4 +1,4 @@
-<div class="resource-view" *ngIf="resource">
+<div class="resource-view" *ngIf="resource && !errorMessage">
 
     <!-- dsp-resource-representation -->
     <!-- TODO: here we will add the resource representation viewers like
@@ -17,4 +17,9 @@
     <ng-template #noProperty>The resource {{resource?.resourceClassLabel}} has no defined properties.</ng-template>
 
 </div>
-<dsp-progress-indicator *ngIf="!resource"></dsp-progress-indicator>
+
+<!-- progress indicator -->
+<dsp-progress-indicator *ngIf="!resource && !errorMessage"></dsp-progress-indicator>
+
+<!-- error message -->
+<dsp-message *ngIf="!resource && errorMessage" [apiError]="errorMessage"></dsp-message>

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
@@ -73,6 +73,8 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
 
     resource: ReadResource;
 
+    errorMessage: ApiResponseError;
+
     resPropInfoVals: PropertyInfoValues[] = []; // array of resource properties
 
     systemPropDefs: SystemPropertyDefinition[] = []; // array of system properties
@@ -145,7 +147,7 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
 
             },
             (error: ApiResponseError) => {
-                console.error('Error to get resource: ', error);
+                this.errorMessage = error;
             });
     }
 

--- a/src/app/action-playground/action-playground.component.html
+++ b/src/app/action-playground/action-playground.component.html
@@ -57,7 +57,7 @@ We will implement the login form here as soon its moved from the old knora-ui.
 <dsp-message [message]="shortMessage" [short]="true"></dsp-message>
 
 <p>Medium</p>
-<dsp-message [message]="errorMessage" [medium]="true"></dsp-message>
+<dsp-message [message]="{status: 404}" [medium]="true"></dsp-message>
 
 <p>Large</p>
 <dsp-message [message]="errorMessage" [short]="false"></dsp-message>

--- a/src/app/action-playground/action-playground.component.html
+++ b/src/app/action-playground/action-playground.component.html
@@ -53,10 +53,15 @@ We will implement the login form here as soon its moved from the old knora-ui.
 <hr>
 
 <p>Message Component</p>
+<p>Short</p>
 <dsp-message [message]="shortMessage" [short]="true"></dsp-message>
-<dsp-message [message]="errorMessage" [short]="true"></dsp-message>
+
+<p>Medium</p>
 <dsp-message [message]="errorMessage" [medium]="true"></dsp-message>
+
+<p>Large</p>
 <dsp-message [message]="errorMessage" [short]="false"></dsp-message>
+
 <p>Open a message with a display duration of 2 seconds</p>
 <button (click)="openMessage()" [disabled]="showTimedMessage">Click me</button>
 <div *ngIf="showTimedMessage">


### PR DESCRIPTION
resolves [DSP-779](https://dasch.myjetbrains.com/youtrack/issue/DSP-779)

For the reviewers:
- Open <http://localhost:4200/action> to see the the message component in action.
- Turn off the whole knora-stack (= server error 503) or only the database `knora-api_db_1` (= server error 500)
  - Open <http://localhost:4200/viewer> to see the server error message 503 or 500
  - Open <http://localhost:4200/search> and do a fulltext search or an expert search to see the server errors