### PR TITLE
Propagate Click Event to Res Viewer Comp.

### DIFF
--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
@@ -7,7 +7,8 @@
             <!-- display value is cast as 'any' because the compiler cannot infer the value type expected by the child component -->
             <dsp-text-value-as-string class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsString'" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-text-value-as-string>
             <dsp-text-value-as-html class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsHtml'" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-text-value-as-html>
-            <dsp-text-value-as-xml class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsXml'" [mode]="mode" [displayValue]="$any(displayValue)" (internalLinkClicked)="standoffLinkClicked($event)"></dsp-text-value-as-xml>
+            <dsp-text-value-as-xml class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsXml'" [mode]="mode" [displayValue]="$any(displayValue)"
+                                   (internalLinkClicked)="standoffLinkClicked($event)" (internalLinkHovered)="standoffLinkHovered($event)"></dsp-text-value-as-xml>
             <dsp-int-value class="parent-value-component" #displayVal *ngSwitchCase="constants.IntValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-int-value>
             <dsp-boolean-value class="parent-value-component" #displayVal *ngSwitchCase="constants.BooleanValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-boolean-value>
             <dsp-uri-value class="parent-value-component" #displayVal *ngSwitchCase="constants.UriValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-uri-value>

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
@@ -7,7 +7,7 @@
             <!-- display value is cast as 'any' because the compiler cannot infer the value type expected by the child component -->
             <dsp-text-value-as-string class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsString'" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-text-value-as-string>
             <dsp-text-value-as-html class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsHtml'" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-text-value-as-html>
-            <dsp-text-value-as-xml class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsXml'" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-text-value-as-xml>
+            <dsp-text-value-as-xml class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsXml'" [mode]="mode" [displayValue]="$any(displayValue)" (internalLinkClicked)="internalLinkClicked($event)"></dsp-text-value-as-xml>
             <dsp-int-value class="parent-value-component" #displayVal *ngSwitchCase="constants.IntValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-int-value>
             <dsp-boolean-value class="parent-value-component" #displayVal *ngSwitchCase="constants.BooleanValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-boolean-value>
             <dsp-uri-value class="parent-value-component" #displayVal *ngSwitchCase="constants.UriValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-uri-value>

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
@@ -17,7 +17,7 @@
             <dsp-time-value class="parent-value-component" #displayVal *ngSwitchCase="constants.TimeValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-time-value>
             <dsp-geoname-value class="parent-value-component" #displayVal *ngSwitchCase="constants.GeonameValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-geoname-value>
             <dsp-link-value class="parent-value-component" #displayVal *ngSwitchCase="constants.LinkValue" [mode]="mode" [displayValue]="$any(displayValue)"
-                        [parentResource]="parentResource" [propIri]="displayValue.property"></dsp-link-value>
+                        [parentResource]="parentResource" [propIri]="displayValue.property" (referredResourceClicked)="referredResourceClicked.emit($event)"></dsp-link-value>
             <dsp-date-value class="parent-value-component" #displayVal *ngSwitchCase="constants.DateValue" [mode]="mode" [displayValue]="$any(displayValue)" [displayOptions]="dateDisplayOptions" [labels]="showDateLabels" [ontologyDateFormat]="dateFormat"></dsp-date-value>
             <dsp-list-value class="parent-value-component" #displayVal *ngSwitchCase="constants.ListValue" [mode]="mode" [displayValue]="$any(displayValue)"
                         [propertyDef]="$any(parentResource.entityInfo.properties[displayValue.property])"></dsp-list-value>

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
@@ -18,7 +18,7 @@
             <dsp-time-value class="parent-value-component" #displayVal *ngSwitchCase="constants.TimeValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-time-value>
             <dsp-geoname-value class="parent-value-component" #displayVal *ngSwitchCase="constants.GeonameValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-geoname-value>
             <dsp-link-value class="parent-value-component" #displayVal *ngSwitchCase="constants.LinkValue" [mode]="mode" [displayValue]="$any(displayValue)"
-                        [parentResource]="parentResource" [propIri]="displayValue.property" (referredResourceClicked)="referredResourceClicked.emit($event)"></dsp-link-value>
+                        [parentResource]="parentResource" [propIri]="displayValue.property" (referredResourceClicked)="referredResourceClicked.emit($event)" (referredResourceHovered)="referredResourceHovered.emit($event)"></dsp-link-value>
             <dsp-date-value class="parent-value-component" #displayVal *ngSwitchCase="constants.DateValue" [mode]="mode" [displayValue]="$any(displayValue)" [displayOptions]="dateDisplayOptions" [labels]="showDateLabels" [ontologyDateFormat]="dateFormat"></dsp-date-value>
             <dsp-list-value class="parent-value-component" #displayVal *ngSwitchCase="constants.ListValue" [mode]="mode" [displayValue]="$any(displayValue)"
                         [propertyDef]="$any(parentResource.entityInfo.properties[displayValue.property])"></dsp-list-value>

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.html
@@ -7,7 +7,7 @@
             <!-- display value is cast as 'any' because the compiler cannot infer the value type expected by the child component -->
             <dsp-text-value-as-string class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsString'" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-text-value-as-string>
             <dsp-text-value-as-html class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsHtml'" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-text-value-as-html>
-            <dsp-text-value-as-xml class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsXml'" [mode]="mode" [displayValue]="$any(displayValue)" (internalLinkClicked)="internalLinkClicked($event)"></dsp-text-value-as-xml>
+            <dsp-text-value-as-xml class="parent-value-component" #displayVal *ngSwitchCase="'ReadTextValueAsXml'" [mode]="mode" [displayValue]="$any(displayValue)" (internalLinkClicked)="standoffLinkClicked($event)"></dsp-text-value-as-xml>
             <dsp-int-value class="parent-value-component" #displayVal *ngSwitchCase="constants.IntValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-int-value>
             <dsp-boolean-value class="parent-value-component" #displayVal *ngSwitchCase="constants.BooleanValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-boolean-value>
             <dsp-uri-value class="parent-value-component" #displayVal *ngSwitchCase="constants.UriValue" [mode]="mode" [displayValue]="$any(displayValue)"></dsp-uri-value>

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -114,6 +114,8 @@ class TestTextValueAsXmlComponent {
     @Input() displayValue;
 
     @Output() internalLinkClicked: EventEmitter<string> = new EventEmitter<string>();
+
+    @Output() internalLinkHovered: EventEmitter<string> = new EventEmitter<string>();
 }
 
 @Component({
@@ -249,7 +251,9 @@ class TestDateValueComponent {
   template: `
       <dsp-display-edit *ngIf="readValue" #displayEditVal [parentResource]="readResource"
                         [displayValue]="readValue"
-                        (referredResourceClicked)="internalLinkClicked($event)"></dsp-display-edit>`
+                        (referredResourceClicked)="internalLinkClicked($event)"
+                        (referredResourceHovered)="internalLinkHovered($event)"
+      ></dsp-display-edit>`
 })
 class TestHostDisplayValueComponent implements OnInit {
 
@@ -260,7 +264,9 @@ class TestHostDisplayValueComponent implements OnInit {
 
   mode: 'read' | 'update' | 'create' | 'search';
 
-  linkVal: ReadLinkValue;
+  linkValClicked: ReadLinkValue;
+
+  linkValHovered: ReadLinkValue;
 
   ngOnInit() {
 
@@ -293,7 +299,11 @@ class TestHostDisplayValueComponent implements OnInit {
   }
 
    internalLinkClicked(linkVal: ReadLinkValue) {
-      this.linkVal = linkVal;
+      this.linkValClicked = linkVal;
+   }
+
+   internalLinkHovered(linkVal: ReadLinkValue) {
+      this.linkValHovered = linkVal;
    }
 }
 
@@ -418,7 +428,7 @@ describe('DisplayEditComponent', () => {
       testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext');
       testHostFixture.detectChanges();
 
-      expect(testHostComponent.linkVal).toBeUndefined();
+      expect(testHostComponent.linkValClicked).toBeUndefined();
 
       expect(testHostComponent.displayEditValueComponent.displayValueComponent instanceof TestTextValueAsXmlComponent).toBe(true);
       expect(testHostComponent.displayEditValueComponent.displayValueComponent.displayValue instanceof ReadTextValueAsXml).toBe(true);
@@ -426,7 +436,24 @@ describe('DisplayEditComponent', () => {
 
       (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestTextValueAsXmlComponent).internalLinkClicked.emit('testIri');
 
-      expect(testHostComponent.linkVal.linkedResourceIri).toEqual('testIri');
+      expect(testHostComponent.linkValClicked.linkedResourceIri).toEqual('testIri');
+
+    });
+
+    it('should choose the apt component for an XML value in the template and react to hovering on a standoff link', () => {
+
+      testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext');
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent.linkValHovered).toBeUndefined();
+
+      expect(testHostComponent.displayEditValueComponent.displayValueComponent instanceof TestTextValueAsXmlComponent).toBe(true);
+      expect(testHostComponent.displayEditValueComponent.displayValueComponent.displayValue instanceof ReadTextValueAsXml).toBe(true);
+      expect(testHostComponent.displayEditValueComponent.displayValueComponent.mode).toEqual('read');
+
+      (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestTextValueAsXmlComponent).internalLinkHovered.emit('testIri');
+
+      expect(testHostComponent.linkValHovered.linkedResourceIri).toEqual('testIri');
 
     });
 
@@ -546,7 +573,7 @@ describe('DisplayEditComponent', () => {
       testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue');
       testHostFixture.detectChanges();
 
-      expect(testHostComponent.linkVal).toBeUndefined();
+      expect(testHostComponent.linkValClicked).toBeUndefined();
 
       expect(testHostComponent.displayEditValueComponent.displayValueComponent instanceof TestLinkValueComponent).toBe(true);
       expect(testHostComponent.displayEditValueComponent.displayValueComponent.displayValue instanceof ReadLinkValue).toBe(true);
@@ -564,7 +591,7 @@ describe('DisplayEditComponent', () => {
           .referredResourceClicked
           .emit((testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestLinkValueComponent).displayValue);
 
-      expect(testHostComponent.linkVal.linkedResourceIri).toEqual('http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ');
+      expect(testHostComponent.linkValClicked.linkedResourceIri).toEqual('http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ');
 
     });
 

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -90,6 +90,8 @@ class TestLinkValueComponent {
   @Input() propIri;
 
   @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter();
+
+  @Output() referredResourceHovered: EventEmitter<ReadLinkValue> = new EventEmitter();
 }
 
 @Component({
@@ -430,10 +432,6 @@ describe('DisplayEditComponent', () => {
 
       expect(testHostComponent.linkValClicked).toBeUndefined();
 
-      expect(testHostComponent.displayEditValueComponent.displayValueComponent instanceof TestTextValueAsXmlComponent).toBe(true);
-      expect(testHostComponent.displayEditValueComponent.displayValueComponent.displayValue instanceof ReadTextValueAsXml).toBe(true);
-      expect(testHostComponent.displayEditValueComponent.displayValueComponent.mode).toEqual('read');
-
       (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestTextValueAsXmlComponent).internalLinkClicked.emit('testIri');
 
       expect(testHostComponent.linkValClicked.linkedResourceIri).toEqual('testIri');
@@ -446,10 +444,6 @@ describe('DisplayEditComponent', () => {
       testHostFixture.detectChanges();
 
       expect(testHostComponent.linkValHovered).toBeUndefined();
-
-      expect(testHostComponent.displayEditValueComponent.displayValueComponent instanceof TestTextValueAsXmlComponent).toBe(true);
-      expect(testHostComponent.displayEditValueComponent.displayValueComponent.displayValue instanceof ReadTextValueAsXml).toBe(true);
-      expect(testHostComponent.displayEditValueComponent.displayValueComponent.mode).toEqual('read');
 
       (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestTextValueAsXmlComponent).internalLinkHovered.emit('testIri');
 
@@ -575,23 +569,26 @@ describe('DisplayEditComponent', () => {
 
       expect(testHostComponent.linkValClicked).toBeUndefined();
 
-      expect(testHostComponent.displayEditValueComponent.displayValueComponent instanceof TestLinkValueComponent).toBe(true);
-      expect(testHostComponent.displayEditValueComponent.displayValueComponent.displayValue instanceof ReadLinkValue).toBe(true);
-      expect((testHostComponent.displayEditValueComponent.displayValueComponent.displayValue as unknown as ReadLinkValue).linkedResourceIri).toEqual('http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ');
-      expect(testHostComponent.displayEditValueComponent.displayValueComponent.mode).toEqual('read');
-      expect((testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestLinkValueComponent).parentResource instanceof ReadResource).toBe(true);
-      expect((testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestLinkValueComponent).propIri).toEqual('http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue');
-
-      const userServiceSpy = TestBed.inject(UserService);
-
-      expect(userServiceSpy.getUser).toHaveBeenCalledTimes(1);
-      expect(userServiceSpy.getUser).toHaveBeenCalledWith('http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ');
-
       (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestLinkValueComponent)
           .referredResourceClicked
           .emit((testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestLinkValueComponent).displayValue);
 
       expect(testHostComponent.linkValClicked.linkedResourceIri).toEqual('http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ');
+
+    });
+
+    it('should choose the apt component for a link value in the template and react to a hover event', () => {
+
+      testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue');
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent.linkValHovered).toBeUndefined();
+
+      (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestLinkValueComponent)
+          .referredResourceHovered
+          .emit((testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestLinkValueComponent).displayValue);
+
+      expect(testHostComponent.linkValHovered.linkedResourceIri).toEqual('http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ');
 
     });
 

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
@@ -150,6 +150,28 @@ export class DisplayEditComponent implements OnInit {
     }
 
     /**
+     * React when a standoff link in a text has received a click event.
+     *
+     * @param resIri the Iri of the resource the standoff link refers to.
+     */
+    internalLinkClicked(resIri: string) {
+
+        const standoffLinkVals: ReadLinkValue[] = this.parentResource.getValuesAs('http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue', ReadLinkValue);
+
+        // find the corresponding standoff link value
+        const referredResStandoffLinkVal: ReadLinkValue[] = standoffLinkVals.filter(
+            standoffLinkVal => {
+                return standoffLinkVal.linkedResourceIri === resIri;
+            }
+        );
+
+        // only emit an event if the corresponding standoff link value could be found
+        if (referredResStandoffLinkVal.length === 1) {
+            this.referredResourceClicked.emit(referredResStandoffLinkVal[0]);
+        }
+    }
+
+    /**
      * Show the form components and CRUD buttons to update an existing value or add a new value.
      */
     activateEditMode() {

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
@@ -71,7 +71,7 @@ export class DisplayEditComponent implements OnInit {
 
     @Input() configuration?: object;
 
-    @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter();
+    @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter<ReadLinkValue>();
 
     constants = Constants;
 

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
@@ -1,20 +1,19 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { Component, Inject, Input, OnInit, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Inject, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import {
-    ApiResponseData,
     ApiResponseError,
     Constants,
     DeleteValue,
     DeleteValueResponse,
     KnoraApiConnection,
     PermissionUtil,
+    ReadLinkValue,
     ReadResource,
     ReadUser,
     ReadValue,
     UpdateResource,
     UpdateValue,
-    UserResponse,
     WriteValueResponse
 } from '@dasch-swiss/dsp-js';
 import { mergeMap } from 'rxjs/operators';
@@ -71,6 +70,8 @@ export class DisplayEditComponent implements OnInit {
     @Input() parentResource: ReadResource;
 
     @Input() configuration?: object;
+
+    @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter();
 
     constants = Constants;
 

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
@@ -154,7 +154,7 @@ export class DisplayEditComponent implements OnInit {
      *
      * @param resIri the Iri of the resource the standoff link refers to.
      */
-    internalLinkClicked(resIri: string) {
+    standoffLinkClicked(resIri: string) {
 
         const standoffLinkVals: ReadLinkValue[] = this.parentResource.getValuesAs('http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue', ReadLinkValue);
 

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
@@ -73,6 +73,8 @@ export class DisplayEditComponent implements OnInit {
 
     @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter<ReadLinkValue>();
 
+    @Output() referredResourceHovered: EventEmitter<ReadLinkValue> = new EventEmitter<ReadLinkValue>();
+
     constants = Constants;
 
     mode: 'read' | 'update' | 'create' | 'search';
@@ -150,12 +152,12 @@ export class DisplayEditComponent implements OnInit {
     }
 
     /**
-     * React when a standoff link in a text has received a click event.
+     * Given a resource Iri, finds the corresponding standoff link value.
+     * Returns an empty array if the standoff link cannot be found.
      *
-     * @param resIri the Iri of the resource the standoff link refers to.
+     * @param resIri the Iri of the resource.
      */
-    standoffLinkClicked(resIri: string) {
-
+    private _getStandoffLinkValueForResource(resIri: string): ReadLinkValue[] {
         const standoffLinkVals: ReadLinkValue[] = this.parentResource.getValuesAs('http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue', ReadLinkValue);
 
         // find the corresponding standoff link value
@@ -165,10 +167,40 @@ export class DisplayEditComponent implements OnInit {
             }
         );
 
+        return referredResStandoffLinkVal;
+    }
+
+    /**
+     * React when a standoff link in a text has received a click event.
+     *
+     * @param resIri the Iri of the resource the standoff link refers to.
+     */
+    standoffLinkClicked(resIri: string): void {
+
+        // find the corresponding standoff link value
+        const referredResStandoffLinkVal: ReadLinkValue[] = this._getStandoffLinkValueForResource(resIri);
+
         // only emit an event if the corresponding standoff link value could be found
         if (referredResStandoffLinkVal.length === 1) {
             this.referredResourceClicked.emit(referredResStandoffLinkVal[0]);
         }
+    }
+
+    /**
+     * React when a standoff link in a text has received a hover event.
+     *
+     * @param resIri the Iri of the resource the standoff link refers to.
+     */
+    standoffLinkHovered(resIri: string): void {
+
+        // find the corresponding standoff link value
+        const referredResStandoffLinkVal: ReadLinkValue[] = this._getStandoffLinkValueForResource(resIri);
+
+        // only emit an event if the corresponding standoff link value could be found
+        if (referredResStandoffLinkVal.length === 1) {
+            this.referredResourceHovered.emit(referredResStandoffLinkVal[0]);
+        }
+
     }
 
     /**

--- a/projects/dsp-ui/src/lib/viewer/values/link-value/link-value.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/link-value/link-value.component.html
@@ -1,5 +1,5 @@
 <span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <span class="rm-value" (click)="refResClicked()">
+    <span class="rm-value" (click)="refResClicked()" (mouseover)="refResHovered()">
         <a class="link">{{valueFormControl.value?.label}}</a>
     </span>
   <span class="rm-comment" *ngIf="shouldShowComment">{{commentFormControl.value}}</span>

--- a/projects/dsp-ui/src/lib/viewer/values/link-value/link-value.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/link-value/link-value.component.spec.ts
@@ -25,7 +25,7 @@ import { LinkValueComponent } from './link-value.component';
 @Component({
   template: `
     <dsp-link-value #inputVal [displayValue]="displayInputVal" [mode]="mode" [parentResource]="parentResource"
-                    [propIri]="propIri" (referredResourceClicked)="refResClicked($event)"></dsp-link-value>`
+                    [propIri]="propIri" (referredResourceClicked)="refResClicked($event)" (referredResourceHovered)="refResHovered($event)"></dsp-link-value>`
 })
 class TestHostDisplayValueComponent implements OnInit {
 
@@ -35,7 +35,8 @@ class TestHostDisplayValueComponent implements OnInit {
   parentResource: ReadResource;
   propIri: string;
   mode: 'read' | 'update' | 'create' | 'search';
-  linkValueSelected: ReadLinkValue;
+  linkValueClicked: ReadLinkValue;
+  linkValueHovered: ReadLinkValue;
 
   ngOnInit() {
 
@@ -52,7 +53,11 @@ class TestHostDisplayValueComponent implements OnInit {
   }
 
   refResClicked(readLinkValue: ReadLinkValue) {
-    this.linkValueSelected = readLinkValue;
+    this.linkValueClicked = readLinkValue;
+  }
+
+  refResHovered(readLinkValue: ReadLinkValue) {
+    this.linkValueHovered = readLinkValue;
   }
 }
 
@@ -417,8 +422,27 @@ describe('LinkValueComponent', () => {
     }));
 
     it('should emit the displayValue when the value is clicked on', () => {
+
+        expect(testHostComponent.linkValueClicked).toBeUndefined();
+
         valueReadModeNativeElement.click();
-        expect(testHostComponent.linkValueSelected).toEqual(testHostComponent.displayInputVal);
+
+        expect(testHostComponent.linkValueClicked).toEqual(testHostComponent.displayInputVal);
+    });
+
+    it('should emit the displayValue when the value is hovered', () => {
+
+        expect(testHostComponent.linkValueHovered).toBeUndefined();
+
+        valueReadModeNativeElement.dispatchEvent(
+            new MouseEvent('mouseover', {
+                view: window,
+                bubbles: true,
+                cancelable: true
+            })
+        );
+
+        expect(testHostComponent.linkValueHovered).toEqual(testHostComponent.displayInputVal);
     });
 
   });

--- a/projects/dsp-ui/src/lib/viewer/values/link-value/link-value.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/link-value/link-value.component.ts
@@ -40,7 +40,11 @@ export class LinkValueComponent extends BaseValueComponent implements OnInit, On
     @Input() displayValue?: ReadLinkValue;
     @Input() parentResource: ReadResource;
     @Input() propIri: string;
+
     @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter();
+
+    @Output() referredResourceHovered: EventEmitter<ReadLinkValue> = new EventEmitter();
+
     resources: ReadResource[] = [];
     restrictToResourceClass: string;
     valueFormControl: FormControl;
@@ -187,9 +191,16 @@ export class LinkValueComponent extends BaseValueComponent implements OnInit, On
     }
 
     /**
-     * Emits the displayValue
+     * Emits the displayValue on click.
      */
     refResClicked() {
         this.referredResourceClicked.emit(this.displayValue);
+    }
+
+    /**
+     * Emits the displayValue on hover.
+     */
+    refResHovered() {
+        this.referredResourceHovered.emit(this.displayValue);
     }
 }

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
@@ -1,5 +1,11 @@
 <span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <div *ngIf="this.displayValue?.mapping === standardMapping; else sourceMode" class="rm-value" dspHtmlLink [innerHTML]="valueFormControl.value" (internalLinkClicked)="internalLinkClicked.emit($event)"></div>
+    <div *ngIf="this.displayValue?.mapping === standardMapping; else sourceMode"
+         class="rm-value"
+         dspHtmlLink
+         [innerHTML]="valueFormControl.value"
+         (internalLinkClicked)="internalLinkClicked.emit($event)"
+         (internalLinkHovered)="internalLinkHovered.emit($event)">
+    </div>
     <ng-template #sourceMode>
         <span class="rm-value">{{displayValue?.xml}}</span>
     </ng-template>

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.html
@@ -1,5 +1,5 @@
 <span *ngIf="mode === 'read'; else showForm" class="read-mode-view">
-    <div *ngIf="this.displayValue?.mapping === standardMapping; else sourceMode" class="rm-value" [innerHTML]="valueFormControl.value"></div>
+    <div *ngIf="this.displayValue?.mapping === standardMapping; else sourceMode" class="rm-value" dspHtmlLink [innerHTML]="valueFormControl.value" (internalLinkClicked)="internalLinkClicked.emit($event)"></div>
     <ng-template #sourceMode>
         <span class="rm-value">{{displayValue?.xml}}</span>
     </ng-template>

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.spec.ts
@@ -1,12 +1,21 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { Component, DebugElement, forwardRef, Input, OnInit, ViewChild } from '@angular/core';
+import {
+    Component,
+    DebugElement,
+    Directive,
+    EventEmitter,
+    forwardRef,
+    Input,
+    OnInit,
+    Output,
+    ViewChild
+} from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CreateTextValueAsXml, MockResource, ReadTextValueAsXml, UpdateTextValueAsXml } from '@dasch-swiss/dsp-js';
-import { AppInitService } from 'projects/dsp-ui/src/lib/core/app-init.service';
 import { TextValueAsXMLComponent } from './text-value-as-xml.component';
 
 /**
@@ -59,7 +68,7 @@ class TestCKEditorComponent implements ControlValueAccessor {
  */
 @Component({
     template: `
-        <dsp-text-value-as-xml #inputVal [displayValue]="displayInputVal" [mode]="mode"></dsp-text-value-as-xml>`
+        <dsp-text-value-as-xml #inputVal [displayValue]="displayInputVal" [mode]="mode" (internalLinkClicked)="standoffLinkClicked($event)"></dsp-text-value-as-xml>`
 })
 class TestHostDisplayValueComponent implements OnInit {
 
@@ -68,6 +77,8 @@ class TestHostDisplayValueComponent implements OnInit {
     displayInputVal: ReadTextValueAsXml;
 
     mode: 'read' | 'update' | 'create' | 'search';
+
+    refRes: string;
 
     ngOnInit() {
 
@@ -80,6 +91,10 @@ class TestHostDisplayValueComponent implements OnInit {
             }
         );
 
+    }
+
+    standoffLinkClicked(refResIri: string) {
+        this.refRes = refResIri;
     }
 }
 
@@ -103,6 +118,15 @@ class TestHostCreateValueComponent implements OnInit {
     }
 }
 
+@Directive({
+    selector: '[dspHtmlLink]'
+})
+export class TestTextValueHtmlLinkDirective {
+
+    @Output() internalLinkClicked = new EventEmitter<string>();
+
+}
+
 describe('TextValueAsXMLComponent', () => {
 
     beforeEach(async(() => {
@@ -111,7 +135,8 @@ describe('TextValueAsXMLComponent', () => {
                 TextValueAsXMLComponent,
                 TestHostDisplayValueComponent,
                 TestCKEditorComponent,
-                TestHostCreateValueComponent
+                TestHostCreateValueComponent,
+                TestTextValueHtmlLinkDirective
             ],
             imports: [
                 ReactiveFormsModule,
@@ -158,6 +183,30 @@ describe('TextValueAsXMLComponent', () => {
             expect(testHostComponent.inputValueComponent.mode).toEqual('read');
 
             expect(valueReadModeNativeElement.innerHTML).toEqual('\n<p>test with <strong>markup</strong></p>');
+
+        });
+
+        it('should display an existing value for the standard mapping as formatted text and react to clicking on a standoff link', () => {
+
+            expect(testHostComponent.inputValueComponent.displayValue.xml).toEqual('<?xml version="1.0" encoding="UTF-8"?>\n<text><p>test with <strong>markup</strong></p></text>');
+
+            expect(testHostComponent.inputValueComponent.form.valid).toBeTruthy();
+
+            expect(testHostComponent.inputValueComponent.mode).toEqual('read');
+
+            expect(valueReadModeNativeElement.innerHTML).toEqual('\n<p>test with <strong>markup</strong></p>');
+
+            expect(testHostComponent.refRes).toBeUndefined();
+
+            const debugElement = valueComponentDe.query(By.directive(TestTextValueHtmlLinkDirective));
+
+            // https://stackoverflow.com/questions/50611721/how-to-access-property-of-directive-in-a-test-host-in-angular-5/51716105
+            const linkDirective = debugElement.injector.get(TestTextValueHtmlLinkDirective);
+
+            // simulate click event on a standoff link
+            linkDirective.internalLinkClicked.emit('testIri');
+
+            expect(testHostComponent.refRes).toEqual('testIri');
 
         });
 

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.spec.ts
@@ -68,7 +68,7 @@ class TestCKEditorComponent implements ControlValueAccessor {
  */
 @Component({
     template: `
-        <dsp-text-value-as-xml #inputVal [displayValue]="displayInputVal" [mode]="mode" (internalLinkClicked)="standoffLinkClicked($event)"></dsp-text-value-as-xml>`
+        <dsp-text-value-as-xml #inputVal [displayValue]="displayInputVal" [mode]="mode" (internalLinkClicked)="standoffLinkClicked($event)" (internalLinkHovered)="standoffLinkHovered($event)"></dsp-text-value-as-xml>`
 })
 class TestHostDisplayValueComponent implements OnInit {
 
@@ -78,7 +78,9 @@ class TestHostDisplayValueComponent implements OnInit {
 
     mode: 'read' | 'update' | 'create' | 'search';
 
-    refRes: string;
+    refResClicked: string;
+
+    refResHovered: string;
 
     ngOnInit() {
 
@@ -94,7 +96,11 @@ class TestHostDisplayValueComponent implements OnInit {
     }
 
     standoffLinkClicked(refResIri: string) {
-        this.refRes = refResIri;
+        this.refResClicked = refResIri;
+    }
+
+    standoffLinkHovered(refResIri: string) {
+        this.refResHovered = refResIri;
     }
 }
 
@@ -124,6 +130,8 @@ class TestHostCreateValueComponent implements OnInit {
 export class TestTextValueHtmlLinkDirective {
 
     @Output() internalLinkClicked = new EventEmitter<string>();
+
+    @Output() internalLinkHovered = new EventEmitter<string>();
 
 }
 
@@ -196,7 +204,7 @@ describe('TextValueAsXMLComponent', () => {
 
             expect(valueReadModeNativeElement.innerHTML).toEqual('\n<p>test with <strong>markup</strong></p>');
 
-            expect(testHostComponent.refRes).toBeUndefined();
+            expect(testHostComponent.refResClicked).toBeUndefined();
 
             const debugElement = valueComponentDe.query(By.directive(TestTextValueHtmlLinkDirective));
 
@@ -206,7 +214,31 @@ describe('TextValueAsXMLComponent', () => {
             // simulate click event on a standoff link
             linkDirective.internalLinkClicked.emit('testIri');
 
-            expect(testHostComponent.refRes).toEqual('testIri');
+            expect(testHostComponent.refResClicked).toEqual('testIri');
+
+        });
+
+        it('should display an existing value for the standard mapping as formatted text and react to hovering on a standoff link', () => {
+
+            expect(testHostComponent.inputValueComponent.displayValue.xml).toEqual('<?xml version="1.0" encoding="UTF-8"?>\n<text><p>test with <strong>markup</strong></p></text>');
+
+            expect(testHostComponent.inputValueComponent.form.valid).toBeTruthy();
+
+            expect(testHostComponent.inputValueComponent.mode).toEqual('read');
+
+            expect(valueReadModeNativeElement.innerHTML).toEqual('\n<p>test with <strong>markup</strong></p>');
+
+            expect(testHostComponent.refResHovered).toBeUndefined();
+
+            const debugElement = valueComponentDe.query(By.directive(TestTextValueHtmlLinkDirective));
+
+            // https://stackoverflow.com/questions/50611721/how-to-access-property-of-directive-in-a-test-host-in-angular-5/51716105
+            const linkDirective = debugElement.injector.get(TestTextValueHtmlLinkDirective);
+
+            // simulate click event on a standoff link
+            linkDirective.internalLinkHovered.emit('testIri');
+
+            expect(testHostComponent.refResHovered).toEqual('testIri');
 
         });
 

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
@@ -30,7 +30,7 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
 
     @Input() displayValue?: ReadTextValueAsXml;
 
-    @Output() internalLinkClicked: EventEmitter<string> = new EventEmitter();
+    @Output() internalLinkClicked: EventEmitter<string> = new EventEmitter<string>();
 
     valueFormControl: FormControl;
     commentFormControl: FormControl;

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
@@ -32,6 +32,8 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
 
     @Output() internalLinkClicked: EventEmitter<string> = new EventEmitter<string>();
 
+    @Output() internalLinkHovered: EventEmitter<string> = new EventEmitter<string>();
+
     valueFormControl: FormControl;
     commentFormControl: FormControl;
 

--- a/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/values/text-value/text-value-as-xml/text-value-as-xml.component.ts
@@ -1,4 +1,14 @@
-import { Component, Inject, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import {
+    Component,
+    EventEmitter,
+    Inject,
+    Input,
+    OnChanges,
+    OnDestroy,
+    OnInit,
+    Output,
+    SimpleChanges
+} from '@angular/core';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { Constants, CreateTextValueAsXml, ReadTextValueAsXml, UpdateTextValueAsXml } from '@dasch-swiss/dsp-js';
 import * as Editor from 'ckeditor5-custom-build';
@@ -19,6 +29,8 @@ export class TextValueAsXMLComponent extends BaseValueComponent implements OnIni
     readonly standardMapping = 'http://rdfh.ch/standoff/mappings/StandardMapping'; // TODO: define this somewhere else
 
     @Input() displayValue?: ReadTextValueAsXml;
+
+    @Output() internalLinkClicked: EventEmitter<string> = new EventEmitter();
 
     valueFormControl: FormControl;
     commentFormControl: FormControl;

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.html
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.html
@@ -21,7 +21,9 @@
                         <dsp-display-edit *ngIf="val"
                             #displayEdit
                             [parentResource]="parentResource"
-                            [displayValue]="val">
+                            [displayValue]="val"
+                            (referredResourceClicked)="referredResourceClicked.emit($event)"
+                        >
                         </dsp-display-edit>
                     </div>
                     <!-- Add value form -->

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.html
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.html
@@ -23,7 +23,7 @@
                             [parentResource]="parentResource"
                             [displayValue]="val"
                             (referredResourceClicked)="referredResourceClicked.emit($event)"
-                        >
+                            (referredResourceHovered)="referredResourceHovered.emit($event)">
                         </dsp-display-edit>
                     </div>
                     <!-- Add value form -->

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.ts
@@ -56,7 +56,7 @@ export class PropertyViewComponent implements OnInit, OnDestroy {
      */
     @Input() showAllProps = false;
 
-    @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter();
+    @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter<ReadLinkValue>();
 
     addButtonIsVisible: boolean; // used to toggle add value button
     addValueFormIsVisible: boolean; // used to toggle add value form field

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.ts
@@ -1,11 +1,18 @@
 import {
-    Component,
+    Component, EventEmitter,
     Input,
     OnDestroy,
     OnInit,
+    Output,
     ViewChild
 } from '@angular/core';
-import { CardinalityUtil, PermissionUtil, ReadResource, ResourcePropertyDefinition, SystemPropertyDefinition } from '@dasch-swiss/dsp-js';
+import {
+    CardinalityUtil,
+    PermissionUtil,
+    ReadLinkValue,
+    ReadResource,
+    SystemPropertyDefinition
+} from '@dasch-swiss/dsp-js';
 import { Subscription } from 'rxjs';
 import { AddValueComponent } from '../../operations/add-value/add-value.component';
 import { DisplayEditComponent } from '../../operations/display-edit/display-edit.component';
@@ -48,6 +55,8 @@ export class PropertyViewComponent implements OnInit, OnDestroy {
      * @param  (showAllProps)
      */
     @Input() showAllProps = false;
+
+    @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter();
 
     addButtonIsVisible: boolean; // used to toggle add value button
     addValueFormIsVisible: boolean; // used to toggle add value form field

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.ts
@@ -58,6 +58,8 @@ export class PropertyViewComponent implements OnInit, OnDestroy {
 
     @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter<ReadLinkValue>();
 
+    @Output() referredResourceHovered: EventEmitter<ReadLinkValue> = new EventEmitter<ReadLinkValue>();
+
     addButtonIsVisible: boolean; // used to toggle add value button
     addValueFormIsVisible: boolean; // used to toggle add value form field
     propID: string; // used in template to show only the add value form of the corresponding value

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.html
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.html
@@ -11,7 +11,12 @@
 
     <!-- dsp-property-view -->
     <dsp-property-view *ngIf="resPropInfoVals.length !== 0 || systemPropDefs.length !== 0; else noProperty"
-        [parentResource]="resource" [propArray]="resPropInfoVals" [systemPropArray]="systemPropDefs" [showAllProps]="showAllProps" (referredResourceClicked)="referredResourceClicked.emit($event)">
+        [parentResource]="resource"
+                       [propArray]="resPropInfoVals"
+                       [systemPropArray]="systemPropDefs"
+                       [showAllProps]="showAllProps"
+                       (referredResourceClicked)="referredResourceClicked.emit($event)"
+                       (referredResourceHovered)="referredResourceHovered.emit($event)">
     </dsp-property-view>
 
     <ng-template #noProperty>The resource {{resource?.resourceClassLabel}} has no defined properties.</ng-template>

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.html
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.html
@@ -11,7 +11,7 @@
 
     <!-- dsp-property-view -->
     <dsp-property-view *ngIf="resPropInfoVals.length !== 0 || systemPropDefs.length !== 0; else noProperty"
-        [parentResource]="resource" [propArray]="resPropInfoVals" [systemPropArray]="systemPropDefs" [showAllProps]="showAllProps">
+        [parentResource]="resource" [propArray]="resPropInfoVals" [systemPropArray]="systemPropDefs" [showAllProps]="showAllProps" (referredResourceClicked)="referredResourceClicked.emit($event)">
     </dsp-property-view>
 
     <ng-template #noProperty>The resource {{resource?.resourceClassLabel}} has no defined properties.</ng-template>

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
@@ -14,6 +14,7 @@ import {
     IHasPropertyWithPropertyDefinition,
     KnoraApiConnection,
     PropertyDefinition,
+    ReadLinkValue,
     ReadProject,
     ReadResource,
     ReadValue,
@@ -71,6 +72,8 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
      * @param  openProject EventEmitter which sends project information to parent component
      */
     @Output() openProject: EventEmitter<ReadProject> = new EventEmitter<ReadProject>();
+
+    @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter();
 
     resource: ReadResource;
 

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
@@ -75,6 +75,8 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
 
     @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter<ReadLinkValue>();
 
+    @Output() referredResourceHovered: EventEmitter<ReadLinkValue> = new EventEmitter<ReadLinkValue>();
+
     resource: ReadResource;
 
     resPropInfoVals: PropertyInfoValues[] = []; // array of resource properties

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
@@ -73,7 +73,7 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
      */
     @Output() openProject: EventEmitter<ReadProject> = new EventEmitter<ReadProject>();
 
-    @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter();
+    @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter<ReadLinkValue>();
 
     resource: ReadResource;
 

--- a/src/app/viewer-playground/viewer-playground.component.html
+++ b/src/app/viewer-playground/viewer-playground.component.html
@@ -3,4 +3,4 @@
     components like one of the representation viewer or the value components. All of them can
     also be used individually.</p>
 
-<dsp-resource-view [iri]="resource" [showToolbar]="true" (openProject)="openProject($event)"></dsp-resource-view>
+<dsp-resource-view [iri]="resource" [showToolbar]="true" (openProject)="openProject($event)" (referredResourceClicked)="refResourceClicked($event)"></dsp-resource-view>

--- a/src/app/viewer-playground/viewer-playground.component.html
+++ b/src/app/viewer-playground/viewer-playground.component.html
@@ -3,4 +3,10 @@
     components like one of the representation viewer or the value components. All of them can
     also be used individually.</p>
 
-<dsp-resource-view [iri]="resource" [showToolbar]="true" (openProject)="openProject($event)" (referredResourceClicked)="refResourceClicked($event)"></dsp-resource-view>
+<dsp-resource-view
+    [iri]="resource"
+    [showToolbar]="true"
+    (openProject)="openProject($event)"
+    (referredResourceClicked)="refResourceClicked($event)"
+    (referredResourceHovered)="refResourceHovered($event)">
+</dsp-resource-view>

--- a/src/app/viewer-playground/viewer-playground.component.ts
+++ b/src/app/viewer-playground/viewer-playground.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { SessionService } from '@dasch-swiss/dsp-ui';
-import { ReadProject } from '@dasch-swiss/dsp-js';
+import { ReadLinkValue, ReadProject } from '@dasch-swiss/dsp-js';
 import { prototype } from 'events';
 
 @Component({
@@ -23,5 +23,9 @@ export class ViewerPlaygroundComponent implements OnInit {
     openProject(project: ReadProject) {
         // here you can redirect a user to the project page
         console.log('redircet to project page e.g. /project/:shortname', project.shortname);
+    }
+
+    refResourceClicked(linkValue: ReadLinkValue) {
+        console.log(linkValue);
     }
 }

--- a/src/app/viewer-playground/viewer-playground.component.ts
+++ b/src/app/viewer-playground/viewer-playground.component.ts
@@ -26,6 +26,10 @@ export class ViewerPlaygroundComponent implements OnInit {
     }
 
     refResourceClicked(linkValue: ReadLinkValue) {
-        console.log(linkValue);
+        console.log('clicked: ', linkValue);
+    }
+
+    refResourceHovered(linkValue: ReadLinkValue) {
+        console.log('hovered: ', linkValue);
     }
 }


### PR DESCRIPTION
resolves DSP-784

How to test this in the playground:
- add a standoff link to the text value on the modify page:
![Screenshot 2020-11-04 at 17 26 38](https://user-images.githubusercontent.com/6000023/98137987-ea666580-1ec2-11eb-968b-ffffdc0487ce.png)
- from the "Viewer Module" tab you can now hover over or click standoff links (test) and links (Sierra) and get some console logs 
 