### PR TITLE
Update standoff link value

### DIFF
--- a/projects/dsp-ui/design-documentation.md
+++ b/projects/dsp-ui/design-documentation.md
@@ -20,6 +20,16 @@ Any pipe relating to the transformation of strings must be placed in the folder 
 
 ## Viewer Module
 
+### Resource View Component
+
+The `ResourceViewComponent` initially gets a resource and passes the retrieved information to its child components to deal with the values.
+As the user adds more values, edits existing ones etc., these changes are reflected in `ResourceViewComponent.resPropInfoVals`. 
+*This means the `ResourceViewComponent.resource` that was initially retrieved still represents the state of the past since its values are not updated.*
+Therefore, solely `ResourceViewComponent.resPropInfoVals` are used to represent a resource's values in the template.
+
+When updating, adding, or deleting an XML text value, ad additional request is performed to retrieve the resource's standoff link values
+which are then updated in `ResourceViewComponent.resPropInfoVals`.
+
 ### CRUD UI Components
 
 The viewer module provides components to perform CRUD operations. 

--- a/projects/dsp-ui/design-documentation.md
+++ b/projects/dsp-ui/design-documentation.md
@@ -25,9 +25,9 @@ Any pipe relating to the transformation of strings must be placed in the folder 
 The `ResourceViewComponent` initially gets a resource and passes the retrieved information to its child components to deal with the values.
 As the user adds more values, edits existing ones etc., these changes are reflected in `ResourceViewComponent.resPropInfoVals`. 
 *This means the `ResourceViewComponent.resource` that was initially retrieved still represents the state of the past since its values are not updated.*
-Therefore, solely `ResourceViewComponent.resPropInfoVals` are used to represent a resource's values in the template.
+Therefore, `ResourceViewComponent.resPropInfoVals` is used solely to represent a resource's values in the template.
 
-When updating, adding, or deleting an XML text value, ad additional request is performed to retrieve the resource's standoff link values
+When updating, adding, or deleting an XML text value, an additional request is performed to retrieve the resource's standoff link values
 which are then updated in `ResourceViewComponent.resPropInfoVals`.
 
 ### CRUD UI Components

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -292,6 +292,7 @@ class TestHostDisplayValueComponent implements OnInit {
     readVal.valueHasComment = comment;
 
     // standoff link value handling
+    // a text value linking to another resource has a corresponding standoff link value
     if (prop === 'http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext') {
 
         // adapt ReadLinkValue so it looks like a standoff link value
@@ -315,6 +316,7 @@ class TestHostDisplayValueComponent implements OnInit {
             guiDef: guiDefinition[0]
         };
 
+        // add standoff link value to property array
         this.propArray.push(propInfo);
     }
 

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -448,8 +448,9 @@ describe('DisplayEditComponent', () => {
 
     });
 
-    it('should choose the apt component for an XML value in the template and react to clicking on a standoff link', () => {
+    it('should react to clicking on a standoff link', () => {
 
+      // assign value also updates the standoff link in propArray
       testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext');
       testHostFixture.detectChanges();
 
@@ -461,8 +462,27 @@ describe('DisplayEditComponent', () => {
 
     });
 
-    it('should choose the apt component for an XML value in the template and react to hovering on a standoff link', () => {
+    it('should not react to clicking on a standoff link when there is no corresponding standoff link value', () => {
 
+      // assign value also updates the standoff link in propArray
+      testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext');
+
+      // simulate situation
+      // where the standoff link was not updated
+      testHostComponent.propArray[0].values = [];
+
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent.linkValClicked).toBeUndefined();
+
+      (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestTextValueAsXmlComponent).internalLinkClicked.emit('testIri');
+
+      expect(testHostComponent.linkValClicked).toBeUndefined();
+    });
+
+    it('should react to hovering on a standoff link', () => {
+
+      // assign value also updates the standoff link in propArray
       testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext');
       testHostFixture.detectChanges();
 
@@ -471,6 +491,25 @@ describe('DisplayEditComponent', () => {
       (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestTextValueAsXmlComponent).internalLinkHovered.emit('testIri');
 
       expect(testHostComponent.linkValHovered.linkedResourceIri).toEqual('testIri');
+
+    });
+
+    it('should not react to hovering on a standoff link when there is no corresponding standoff link value', () => {
+
+      // assign value also updates the standoff link in propArray
+      testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext');
+
+      // simulate situation
+      // where the standoff link was not updated
+      testHostComponent.propArray[0].values = [];
+
+      testHostFixture.detectChanges();
+
+      expect(testHostComponent.linkValHovered).toBeUndefined();
+
+      (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestTextValueAsXmlComponent).internalLinkHovered.emit('testIri');
+
+      expect(testHostComponent.linkValHovered).toBeUndefined();
 
     });
 

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -51,6 +51,7 @@ import {
 } from '../../services/value-operation-event.service';
 import { ValueService } from '../../services/value.service';
 import { DisplayEditComponent } from './display-edit.component';
+import { PropertyInfoValues } from '../../views/resource-view/resource-view.component';
 
 @Component({
   selector: `dsp-text-value-as-string`,
@@ -253,6 +254,7 @@ class TestDateValueComponent {
   template: `
       <dsp-display-edit *ngIf="readValue" #displayEditVal [parentResource]="readResource"
                         [displayValue]="readValue"
+                        [propArray]="propArray"
                         (referredResourceClicked)="internalLinkClicked($event)"
                         (referredResourceHovered)="internalLinkHovered($event)"
       ></dsp-display-edit>`
@@ -263,6 +265,7 @@ class TestHostDisplayValueComponent implements OnInit {
 
   readResource: ReadResource;
   readValue: ReadValue;
+  propArray: PropertyInfoValues[] = [];
 
   mode: 'read' | 'update' | 'create' | 'search';
 
@@ -290,11 +293,29 @@ class TestHostDisplayValueComponent implements OnInit {
 
     // standoff link value handling
     if (prop === 'http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext') {
+
+        // adapt ReadLinkValue so it looks like a standoff link value
         const standoffLinkVal: ReadLinkValue
             = this.readResource.getValuesAs('http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue', ReadLinkValue)[0];
 
         standoffLinkVal.linkedResourceIri = 'testIri';
-        this.readResource.properties['http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue'] = [standoffLinkVal];
+
+        const propDefinition = this.readResource.entityInfo.properties['http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue'];
+        propDefinition.id = 'http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue';
+
+        const guiDefinition = this.readResource.entityInfo.classes['http://0.0.0.0:3333/ontology/0001/anything/v2#Thing'].propertiesList.filter(
+            propDefForGui => propDefForGui.propertyIndex === 'http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue'
+        );
+
+        guiDefinition[0].propertyIndex = 'http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue';
+
+        const propInfo: PropertyInfoValues = {
+            values: [standoffLinkVal],
+            propDef: propDefinition,
+            guiDef: guiDefinition[0]
+        };
+
+        this.propArray.push(propInfo);
     }
 
     this.readValue = readVal;

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -269,9 +269,9 @@ class TestHostDisplayValueComponent implements OnInit {
 
   mode: 'read' | 'update' | 'create' | 'search';
 
-  linkValClicked: ReadLinkValue;
-
-  linkValHovered: ReadLinkValue;
+  linkValClicked: ReadLinkValue | string = 'init'; // "init" is set because there is a test that checks that this does not emit for standoff links
+                                                   // (and if it emits undefined because of a bug, we cannot check)
+  linkValHovered: ReadLinkValue | string = 'init'; // see comment above
 
   ngOnInit() {
 
@@ -454,11 +454,11 @@ describe('DisplayEditComponent', () => {
       testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext');
       testHostFixture.detectChanges();
 
-      expect(testHostComponent.linkValClicked).toBeUndefined();
+      expect(testHostComponent.linkValClicked).toEqual('init');
 
       (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestTextValueAsXmlComponent).internalLinkClicked.emit('testIri');
 
-      expect(testHostComponent.linkValClicked.linkedResourceIri).toEqual('testIri');
+      expect((testHostComponent.linkValClicked as ReadLinkValue).linkedResourceIri).toEqual('testIri');
 
     });
 
@@ -473,11 +473,11 @@ describe('DisplayEditComponent', () => {
 
       testHostFixture.detectChanges();
 
-      expect(testHostComponent.linkValClicked).toBeUndefined();
+      expect(testHostComponent.linkValClicked).toEqual('init');
 
       (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestTextValueAsXmlComponent).internalLinkClicked.emit('testIri');
 
-      expect(testHostComponent.linkValClicked).toBeUndefined();
+      expect(testHostComponent.linkValClicked).toEqual('init');
     });
 
     it('should react to hovering on a standoff link', () => {
@@ -486,11 +486,11 @@ describe('DisplayEditComponent', () => {
       testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext');
       testHostFixture.detectChanges();
 
-      expect(testHostComponent.linkValHovered).toBeUndefined();
+      expect(testHostComponent.linkValHovered).toEqual('init');
 
       (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestTextValueAsXmlComponent).internalLinkHovered.emit('testIri');
 
-      expect(testHostComponent.linkValHovered.linkedResourceIri).toEqual('testIri');
+      expect((testHostComponent.linkValHovered as ReadLinkValue).linkedResourceIri).toEqual('testIri');
 
     });
 
@@ -505,11 +505,11 @@ describe('DisplayEditComponent', () => {
 
       testHostFixture.detectChanges();
 
-      expect(testHostComponent.linkValHovered).toBeUndefined();
+      expect(testHostComponent.linkValHovered).toEqual('init');
 
       (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestTextValueAsXmlComponent).internalLinkHovered.emit('testIri');
 
-      expect(testHostComponent.linkValHovered).toBeUndefined();
+      expect(testHostComponent.linkValHovered).toEqual('init');
 
     });
 
@@ -629,13 +629,13 @@ describe('DisplayEditComponent', () => {
       testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue');
       testHostFixture.detectChanges();
 
-      expect(testHostComponent.linkValClicked).toBeUndefined();
+      expect(testHostComponent.linkValClicked).toEqual('init');
 
       (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestLinkValueComponent)
           .referredResourceClicked
           .emit((testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestLinkValueComponent).displayValue);
 
-      expect(testHostComponent.linkValClicked.linkedResourceIri).toEqual('http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ');
+      expect((testHostComponent.linkValClicked as ReadLinkValue).linkedResourceIri).toEqual('http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ');
 
     });
 
@@ -644,13 +644,13 @@ describe('DisplayEditComponent', () => {
       testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue');
       testHostFixture.detectChanges();
 
-      expect(testHostComponent.linkValHovered).toBeUndefined();
+      expect(testHostComponent.linkValHovered).toEqual('init');
 
       (testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestLinkValueComponent)
           .referredResourceHovered
           .emit((testHostComponent.displayEditValueComponent.displayValueComponent as unknown as TestLinkValueComponent).displayValue);
 
-      expect(testHostComponent.linkValHovered.linkedResourceIri).toEqual('http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ');
+      expect((testHostComponent.linkValHovered as ReadLinkValue).linkedResourceIri).toEqual('http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ');
 
     });
 

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
@@ -161,6 +161,7 @@ export class DisplayEditComponent implements OnInit {
      * @param resIri the Iri of the resource.
      */
     private _getStandoffLinkValueForResource(resIri: string): ReadLinkValue[] {
+
         const standoffLinkPropInfoVals: PropertyInfoValues[] = this.propArray.filter(
             resPropInfoVal => {
                 return resPropInfoVal.propDef.id === "http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue";

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
@@ -33,6 +33,7 @@ import {
 } from '../../services/value-operation-event.service';
 import { ValueService } from '../../services/value.service';
 import { BaseValueComponent } from '../../values/base-value.component';
+import { PropertyInfoValues } from '../../views/resource-view/resource-view.component';
 
 @Component({
     selector: 'dsp-display-edit',
@@ -66,6 +67,8 @@ export class DisplayEditComponent implements OnInit {
     @ViewChild('displayVal') displayValueComponent: BaseValueComponent;
 
     @Input() displayValue: ReadValue;
+
+    @Input() propArray: PropertyInfoValues[];
 
     @Input() parentResource: ReadResource;
 
@@ -158,16 +161,27 @@ export class DisplayEditComponent implements OnInit {
      * @param resIri the Iri of the resource.
      */
     private _getStandoffLinkValueForResource(resIri: string): ReadLinkValue[] {
-        const standoffLinkVals: ReadLinkValue[] = this.parentResource.getValuesAs('http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue', ReadLinkValue);
-
-        // find the corresponding standoff link value
-        const referredResStandoffLinkVal: ReadLinkValue[] = standoffLinkVals.filter(
-            standoffLinkVal => {
-                return standoffLinkVal.linkedResourceIri === resIri;
+        const standoffLinkPropInfoVals: PropertyInfoValues[] = this.propArray.filter(
+            resPropInfoVal => {
+                return resPropInfoVal.propDef.id === "http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue";
             }
         );
 
-        return referredResStandoffLinkVal;
+        if (standoffLinkPropInfoVals.length === 1) {
+
+            // find the corresponding standoff link value
+            const referredResStandoffLinkVal: ReadValue[] = standoffLinkPropInfoVals[0].values.filter(
+                (standoffLinkVal: ReadValue) => {
+                    return standoffLinkVal instanceof ReadLinkValue
+                        && (standoffLinkVal as ReadLinkValue).linkedResourceIri === resIri;
+                }
+            );
+
+            return referredResStandoffLinkVal as ReadLinkValue[];
+
+        } else {
+            return [];
+        }
     }
 
     /**

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
@@ -162,6 +162,7 @@ export class DisplayEditComponent implements OnInit {
      */
     private _getStandoffLinkValueForResource(resIri: string): ReadLinkValue[] {
 
+        // find the PropertyInfoValues for the standoff link value
         const standoffLinkPropInfoVals: PropertyInfoValues[] = this.propArray.filter(
             resPropInfoVal => {
                 return resPropInfoVal.propDef.id === "http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue";
@@ -178,9 +179,13 @@ export class DisplayEditComponent implements OnInit {
                 }
             );
 
+            // if no corresponding standoff link value was found,
+            // this array is empty
             return referredResStandoffLinkVal as ReadLinkValue[];
 
         } else {
+            // this should actually never happen
+            // because all resource types have a cardinality for a standoff link value
             return [];
         }
     }

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.html
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.html
@@ -24,6 +24,7 @@
                             #displayEdit
                             [parentResource]="parentResource"
                             [displayValue]="val"
+                            [propArray]="propArray"
                             (referredResourceClicked)="referredResourceClicked.emit($event)"
                             (referredResourceHovered)="referredResourceHovered.emit($event)">
                         </dsp-display-edit>

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -7,6 +7,7 @@ import {
     ApiResponseError,
     IHasPropertyWithPropertyDefinition,
     MockResource,
+    ReadLinkValue,
     ReadResource,
     ReadValue,
     ResourcePropertyDefinition,
@@ -26,7 +27,9 @@ import { PropertyViewComponent } from './property-view.component';
       [parentResource]="parentResource"
       [propArray]="propArray"
       [systemPropArray]="systemPropArray"
-      [showAllProps]="showAllProps">
+      [showAllProps]="showAllProps"
+      (referredResourceClicked)="internalLinkClicked($event)"
+      (referredResourceHovered)="internalLinkHovered($event)">
     </dsp-property-view>`
 })
 class TestPropertyParentComponent implements OnInit, OnDestroy {
@@ -44,6 +47,10 @@ class TestPropertyParentComponent implements OnInit, OnDestroy {
     voeSubscription: Subscription;
 
     myNum = 0;
+
+    linkValClicked: ReadLinkValue;
+
+    linkValHovered: ReadLinkValue;
 
     constructor(public _valueOperationEventService: ValueOperationEventService) { }
 
@@ -76,10 +83,19 @@ class TestPropertyParentComponent implements OnInit, OnDestroy {
             console.error('Error to get the mock resource', error);
         });
     }
+
     ngOnDestroy() {
         if (this.voeSubscription) {
             this.voeSubscription.unsubscribe();
         }
+    }
+
+    internalLinkClicked(linkVal: ReadLinkValue) {
+        this.linkValClicked = linkVal;
+    }
+
+    internalLinkHovered(linkVal: ReadLinkValue) {
+        this.linkValHovered = linkVal;
     }
 }
 
@@ -96,6 +112,9 @@ class TestDisplayValueComponent {
     @Input() displayValue: ReadValue;
     @Input() propArray: PropertyInfoValues[];
     @Input() configuration?: object;
+
+    @Output() referredResourceClicked: EventEmitter<ReadLinkValue> = new EventEmitter<ReadLinkValue>();
+    @Output() referredResourceHovered: EventEmitter<ReadLinkValue> = new EventEmitter<ReadLinkValue>();
 
 }
 
@@ -180,6 +199,36 @@ describe('PropertyViewComponent', () => {
 
         // check if the first system property is an ARK url
         expect(testHostComponent.systemPropArray[0].label).toEqual('ARK URL');
+
+    });
+
+    it('should propagate a click event on a link value', () => {
+
+        const displayEdit = testHostFixture.debugElement.query(By.directive(TestDisplayValueComponent));
+
+        const linkVal = new ReadLinkValue();
+        linkVal.linkedResourceIri = 'testIri';
+
+        expect(testHostComponent.linkValClicked).toBeUndefined();
+
+        (displayEdit.componentInstance as TestDisplayValueComponent).referredResourceClicked.emit(linkVal);
+
+        expect(testHostComponent.linkValClicked.linkedResourceIri).toEqual('testIri');
+
+    });
+
+    it('should propagate a hover event on a link value', () => {
+
+        const displayEdit = testHostFixture.debugElement.query(By.directive(TestDisplayValueComponent));
+
+        const linkVal = new ReadLinkValue();
+        linkVal.linkedResourceIri = 'testIri';
+
+        expect(testHostComponent.linkValHovered).toBeUndefined();
+
+        (displayEdit.componentInstance as TestDisplayValueComponent).referredResourceHovered.emit(linkVal);
+
+        expect(testHostComponent.linkValHovered.linkedResourceIri).toEqual('testIri');
 
     });
 

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.spec.ts
@@ -94,6 +94,7 @@ class TestDisplayValueComponent {
 
     @Input() parentResource: ReadResource;
     @Input() displayValue: ReadValue;
+    @Input() propArray: PropertyInfoValues[];
     @Input() configuration?: object;
 
 }

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.spec.ts
@@ -197,11 +197,6 @@ describe('ResourceViewComponent', () => {
 
         expect((propArrayIntValues[0].values[1] as ReadIntValue).int).toEqual(123);
 
-        const propArrStandoffLinkValues = testHostComponent.resourceViewComponent.resPropInfoVals.filter(
-            propInfoValueArray => propInfoValueArray.propDef.id === 'http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue'
-        );
-
-        expect(propArrStandoffLinkValues[0].values.length).toEqual(0);
     });
 
     it('should add a value to a property of a resource updating the standoff link values', () => {
@@ -232,7 +227,7 @@ describe('ResourceViewComponent', () => {
 
         const newReadXmlValue = new ReadTextValueAsXml();
 
-        newReadXmlValue.xml = '<?xml version="1.0" encoding="UTF-8"?>\n<text><p>test</p></text>';
+        newReadXmlValue.xml = '<?xml version="1.0" encoding="UTF-8"?>\n<text><p><a href="testId" class="salsah-link">test-link</a></p></text>';
         newReadXmlValue.property = 'http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext';
 
         testHostComponent.resourceViewComponent.addValueToResource(newReadXmlValue);
@@ -247,9 +242,27 @@ describe('ResourceViewComponent', () => {
 
         expect(propArrayXmlValues[0].values.length).toEqual(2);
 
-        expect((propArrayXmlValues[0].values[1] as ReadTextValueAsXml).xml).toEqual('<?xml version="1.0" encoding="UTF-8"?>\n<text><p>test</p></text>');
+        expect((propArrayXmlValues[0].values[1] as ReadTextValueAsXml).xml).toEqual('<?xml version="1.0" encoding="UTF-8"?>\n<text><p><a href="testId" class="salsah-link">test-link</a></p></text>');
 
         expect(propArrStandoffLinkValues[0].values.length).toEqual(1);
+
+        expect(resSpy.v2.search.doExtendedSearch).toHaveBeenCalledTimes(1);
+
+        const expectedQuery = `
+ PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+ CONSTRUCT {
+     ?res knora-api:isMainResource true .
+     ?res knora-api:hasStandoffLinkTo ?target .
+ } WHERE {
+     BIND(<http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw> as ?res) .
+     OPTIONAL {
+         ?res knora-api:hasStandoffLinkTo ?target .
+     }
+ }
+ OFFSET 0
+ `;
+
+        expect(resSpy.v2.search.doExtendedSearch).toHaveBeenCalledWith(expectedQuery);
     });
 
     it('should delete an int value from a property of a resource', () => {

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.spec.ts
@@ -199,11 +199,11 @@ describe('ResourceViewComponent', () => {
 
     });
 
-    it('should add a value to a property of a resource updating the standoff link values', () => {
+    it('should add an XML text value to a property of a resource updating the standoff link value', () => {
 
         const resSpy = TestBed.inject(DspApiConnectionToken);
 
-        // once the Xml text value is added, there will be a standoff link val
+        // once the XML text value is added, there will be a standoff link val
         (resSpy.v2.search as jasmine.SpyObj<SearchEndpointV2>).doExtendedSearch.and.callFake(
             (query: string) => {
 
@@ -213,8 +213,8 @@ describe('ResourceViewComponent', () => {
 
                             const linkVal = res.getValuesAs('http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue', ReadLinkValue);
 
-                            linkVal[0].id = 'testId';
                             linkVal[0].property = 'http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue';
+                            linkVal[0].linkedResourceIri = 'testId';
 
                             res.properties['http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue'] = linkVal;
 
@@ -231,8 +231,6 @@ describe('ResourceViewComponent', () => {
         newReadXmlValue.xml = '<?xml version="1.0" encoding="UTF-8"?>\n<text><p><a href="testId" class="salsah-link">test-link</a></p></text>';
         newReadXmlValue.property = 'http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext';
 
-        testHostComponent.resourceViewComponent.addValueToResource(newReadXmlValue);
-
         const propArrayXmlValues = testHostComponent.resourceViewComponent.resPropInfoVals.filter(
             propInfoValueArray => propInfoValueArray.propDef.id === newReadXmlValue.property
         );
@@ -241,11 +239,19 @@ describe('ResourceViewComponent', () => {
             propInfoValueArray => propInfoValueArray.propDef.id === 'http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue'
         );
 
+        expect(propArrayXmlValues[0].values.length).toEqual(1);
+
+        expect(propArrStandoffLinkValues[0].values.length).toEqual(0);
+
+        testHostComponent.resourceViewComponent.addValueToResource(newReadXmlValue);
+
         expect(propArrayXmlValues[0].values.length).toEqual(2);
 
         expect((propArrayXmlValues[0].values[1] as ReadTextValueAsXml).xml).toEqual('<?xml version="1.0" encoding="UTF-8"?>\n<text><p><a href="testId" class="salsah-link">test-link</a></p></text>');
 
         expect(propArrStandoffLinkValues[0].values.length).toEqual(1);
+
+        expect((propArrStandoffLinkValues[0].values[0] as ReadLinkValue).linkedResourceIri).toEqual('testId');
 
         expect(resSpy.v2.search.doExtendedSearch).toHaveBeenCalledTimes(1);
 

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.spec.ts
@@ -337,6 +337,7 @@ describe('ResourceViewComponent', () => {
                 return MockResource.getTestthing().pipe(
                     map(
                         res => {
+                            // no standoff link link value exists anymore
                             return new ReadResourceSequence([res]);
                         }
                     )
@@ -356,12 +357,12 @@ describe('ResourceViewComponent', () => {
             propInfo => propInfo.propDef.id === 'http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext'
         );
 
-        // add value
-        existingXmlVal[0].values.push(readTextValueAsXml);
-
         const existingStandoffLinkVal = testHostComponent.resourceViewComponent.resPropInfoVals.filter(
             propInfo => propInfo.propDef.id === 'http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue'
         );
+
+        // add value
+        existingXmlVal[0].values.push(readTextValueAsXml);
 
         const standoffLinkVal = new ReadLinkValue();
 
@@ -371,7 +372,11 @@ describe('ResourceViewComponent', () => {
         // add corresponding link val
         existingStandoffLinkVal[0].values.push(standoffLinkVal);
 
+        expect(existingXmlVal[0].values.length).toEqual(2);
+        expect(existingStandoffLinkVal[0].values.length).toEqual(1);
+
         // delete the value
+        // after that, there won't be any standoff link value
         const valueToBeDeleted = new DeleteValue();
 
         valueToBeDeleted.id = 'myNewReadTextValueAsXmlId';

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.spec.ts
@@ -446,7 +446,7 @@ describe('ResourceViewComponent', () => {
 
         const resSpy = TestBed.inject(DspApiConnectionToken);
 
-        // once the Xml text value is updated, there will be a standoff link val
+        // once the XML text value is updated, there will be a standoff link value
         (resSpy.v2.search as jasmine.SpyObj<SearchEndpointV2>).doExtendedSearch.and.callFake(
             (query: string) => {
 
@@ -456,7 +456,7 @@ describe('ResourceViewComponent', () => {
 
                             const linkVal = res.getValuesAs('http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue', ReadLinkValue);
 
-                            linkVal[0].id = 'testId';
+                            linkVal[0].linkedResourceIri = 'testId';
                             linkVal[0].property = 'http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue';
 
                             res.properties['http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue'] = linkVal;
@@ -479,15 +479,15 @@ describe('ResourceViewComponent', () => {
             propInfoValueArray => propInfoValueArray.propDef.id === newReadXmlValue.property
         );
 
+        const propArrStandoffLinkValues = testHostComponent.resourceViewComponent.resPropInfoVals.filter(
+            propInfoValueArray => propInfoValueArray.propDef.id === 'http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue'
+        );
+
         propArrayXmlValues[0].values.push(newReadXmlValue);
 
         expect(propArrayXmlValues[0].values.length).toEqual(2);
 
         expect((propArrayXmlValues[0].values[1] as ReadTextValueAsXml).xml).toEqual('<?xml version="1.0" encoding="UTF-8"?><text><p>test</p></text>');
-
-        const propArrStandoffLinkValues = testHostComponent.resourceViewComponent.resPropInfoVals.filter(
-            propInfoValueArray => propInfoValueArray.propDef.id === 'http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue'
-        );
 
         expect(propArrStandoffLinkValues[0].values.length).toEqual(0);
 
@@ -503,6 +503,8 @@ describe('ResourceViewComponent', () => {
         expect((propArrayXmlValues[0].values[1] as ReadTextValueAsXml).xml).toEqual('<?xml version="1.0" encoding="UTF-8"?><text><p><a href="testId" class="salsah-link">test-link</a></p></text>');
 
         expect(propArrStandoffLinkValues[0].values.length).toEqual(1);
+
+        expect((propArrStandoffLinkValues[0].values[0] as ReadLinkValue).linkedResourceIri).toEqual('testId');
 
         expect(resSpy.v2.search.doExtendedSearch).toHaveBeenCalledTimes(1);
 

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
@@ -277,6 +277,12 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
 
         this._dspApiConnection.v2.search.doExtendedSearch(gravsearchQuery).subscribe(
             (res: ReadResourceSequence) => {
+
+                // one resource is expected
+                if (res.resources.length !== 1) {
+                    return;
+                }
+
                 const newStandoffLinkVals = res.resources[0].getValuesAs('http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue', ReadLinkValue);
 
                 this.resPropInfoVals.filter(

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
@@ -258,6 +258,9 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
     private _updateStandoffLinkValue() {
 
         if (this.resource === undefined) {
+            // this should never happen:
+            // if the user was able to click on a standoff link,
+            // then the resource must have been initialised before.
             return;
         }
 

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
@@ -255,7 +255,7 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
      * Updates the standoff link value for the resource being displayed.
      *
      */
-    private _updateStandoffLinkValue() {
+    private _updateStandoffLinkValue(): void {
 
         if (this.resource === undefined) {
             // this should never happen:

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
@@ -16,8 +16,10 @@ import {
     PropertyDefinition,
     ReadLinkValue,
     ReadProject,
-    ReadResource, ReadResourceSequence,
-    ReadStillImageFileValue, ReadTextValueAsXml,
+    ReadResource,
+    ReadResourceSequence,
+    ReadStillImageFileValue,
+    ReadTextValueAsXml,
     ReadValue,
     SystemPropertyDefinition
 } from '@dasch-swiss/dsp-js';
@@ -279,11 +281,11 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
 
         this._dspApiConnection.v2.search.doExtendedSearch(gravsearchQuery).subscribe(
             (res: ReadResourceSequence) => {
-                const newStandoffLinkVals = res.resources[0].getValuesAs("http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue", ReadLinkValue);
+                const newStandoffLinkVals = res.resources[0].getValuesAs('http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue', ReadLinkValue);
 
                 this.resPropInfoVals.filter(
                     resPropInfoVal => {
-                        return resPropInfoVal.propDef.id === "http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue";
+                        return resPropInfoVal.propDef.id === 'http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue';
                     }
                 ).forEach(
                     standoffLinkResPropInfoVal => {

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
@@ -281,14 +281,21 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
             (res: ReadResourceSequence) => {
                 const newStandoffLinkVals = res.resources[0].getValuesAs("http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue", ReadLinkValue);
 
-                const existingStandoffLinkVals = this.resPropInfoVals.filter(
+                this.resPropInfoVals.filter(
                     resPropInfoVal => {
                         return resPropInfoVal.propDef.id === "http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue";
                     }
-                );
-
-                console.log(existingStandoffLinkVals);
-                console.log(newStandoffLinkVals);
+                ).forEach(
+                    standoffLinkResPropInfoVal => {
+                        // delete all the existing standoff link values
+                        standoffLinkResPropInfoVal.values = [];
+                        // push standoff link values retrieved for the resource
+                        newStandoffLinkVals.forEach(
+                            standoffLinkVal => {
+                                standoffLinkResPropInfoVal.values.push(standoffLinkVal);
+                            }
+                        );
+                    });
 
             },
             err => {

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
@@ -277,7 +277,7 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
      }
  }
  OFFSET 0
-        `;
+ `;
 
         this._dspApiConnection.v2.search.doExtendedSearch(gravsearchQuery).subscribe(
             (res: ReadResourceSequence) => {

--- a/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/resource-view/resource-view.component.ts
@@ -185,7 +185,6 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
      * @param valueToAdd the value to add to the end of the values array of the filtered property
      */
     addValueToResource(valueToAdd: ReadValue): void {
-        console.log("add: ", valueToAdd, valueToAdd instanceof ReadTextValueAsXml);
         if (this.resPropInfoVals) {
             this.resPropInfoVals
                 .filter(propInfoValueArray =>
@@ -207,7 +206,6 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
      * @param updatedValue the value to replace valueToReplace with
      */
     updateValueInResource(valueToReplace: ReadValue, updatedValue: ReadValue): void {
-        console.log("updated: ", valueToReplace, updatedValue, updatedValue instanceof ReadTextValueAsXml);
         if (this.resPropInfoVals && updatedValue !== null) {
             this.resPropInfoVals
                 .filter(propInfoValueArray =>
@@ -233,7 +231,6 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
      * @param valueToDelete the value to remove from the values array of the filtered property
      */
     deleteValueFromResource(valueToDelete: DeleteValue): void {
-        console.log("delete1: ", valueToDelete);
         if (this.resPropInfoVals) {
             this.resPropInfoVals
                 .filter(propInfoValueArray =>  // filter to the correct type
@@ -241,7 +238,6 @@ export class ResourceViewComponent implements OnInit, OnChanges, OnDestroy {
                 .forEach(filteredpropInfoValueArray => {
                     filteredpropInfoValueArray.values.forEach((val, index) => { // loop through each value of the current property
                         if (val.id === valueToDelete.id) { // find the value that was deleted using the id
-                            console.log("delete2: ", val, val instanceof ReadTextValueAsXml);
                             filteredpropInfoValueArray.values.splice(index, 1); // remove the value from the values array
                             if (val instanceof ReadTextValueAsXml) {
                                 this._updateStandoffLinkValue();

--- a/src/app/modify/modify.component.html
+++ b/src/app/modify/modify.component.html
@@ -1,2 +1,2 @@
-<dsp-resource-view *ngIf="!loading" [iri]="resourceIri"></dsp-resource-view>
+<dsp-resource-view *ngIf="!loading" [iri]="resourceIri" (referredResourceClicked)="internalLinkClicked($event)"></dsp-resource-view>
 <dsp-progress-indicator *ngIf="loading"></dsp-progress-indicator>

--- a/src/app/modify/modify.component.ts
+++ b/src/app/modify/modify.component.ts
@@ -4,7 +4,8 @@ import {
     ApiResponseData,
     ApiResponseError,
     KnoraApiConnection,
-    LoginResponse
+    LoginResponse,
+    ReadLinkValue
 } from '@dasch-swiss/dsp-js';
 
 @Component({
@@ -30,6 +31,10 @@ export class ModifyComponent implements OnInit {
                 console.log('User failed to log in');
             }
         );
+    }
+
+    internalLinkClicked(linkVal: ReadLinkValue) {
+        console.log(linkVal);
     }
 
 }


### PR DESCRIPTION
resolves DSP-1002

When adding an internal link to a text value, Knora creates a corresponding standoff link value.
When clicking on or hovering over a standoff link, this information can be used to emit the `ReadLinkValue`. Since this requires access to the standoff link value from the text value, `@Input() propArray: PropertyInfoValues[];` was added to `DisplayEditComponent`.
