### PR TITLE
Add missing decorator to ValueOperationEventService

### DIFF
--- a/projects/dsp-ui/src/lib/viewer/services/value-operation-event.service.ts
+++ b/projects/dsp-ui/src/lib/viewer/services/value-operation-event.service.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { DeleteValue, ReadValue } from '@dasch-swiss/dsp-js';
 import { Subject, Subscription } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
@@ -9,6 +10,7 @@ import { filter, map } from 'rxjs/operators';
  * The ValueOperationEventService essentially creates a direct communication channel between
  * the emitting component and the listening component.
  */
+@Injectable() // must be provided on component level, i.d. resource view component.
 export class ValueOperationEventService {
 
     // Create a subject to hold data which can be subscribed to.

--- a/projects/dsp-ui/src/lib/viewer/services/value-operation-event.service.ts
+++ b/projects/dsp-ui/src/lib/viewer/services/value-operation-event.service.ts
@@ -10,7 +10,7 @@ import { filter, map } from 'rxjs/operators';
  * The ValueOperationEventService essentially creates a direct communication channel between
  * the emitting component and the listening component.
  */
-@Injectable() // must be provided on component level, i.d. resource view component.
+@Injectable() // must be provided on component level, i.e. resource view component.
 export class ValueOperationEventService {
 
     // Create a subject to hold data which can be subscribed to.


### PR DESCRIPTION
This PRs adds the missing decorator to `ValueOperationEventService`.

https://angular.io/api/core/Injectable#usage-notes:

> Marking a class with @Injectable ensures that the compiler will generate the necessary metadata to create the class's dependencies when the class is injected.
