### PR TITLE
Determine from ontology if a property is read-only

### DIFF
--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -928,6 +928,7 @@ describe('DisplayEditComponent', () => {
     it('should not display the edit button', () => {
       const inputVal: ReadTextValueAsHtml = new ReadTextValueAsHtml();
 
+      inputVal.property = 'http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext';
       inputVal.hasPermissions = 'CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser';
       inputVal.userHasPermission = 'CR';
       inputVal.type = 'http://api.knora.org/ontology/knora-api/v2#TextValue';

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -333,7 +333,7 @@ class TestHostDisplayValueComponent implements OnInit {
    }
 }
 
-fdescribe('DisplayEditComponent', () => {
+describe('DisplayEditComponent', () => {
   let testHostComponent: TestHostDisplayValueComponent;
   let testHostFixture: ComponentFixture<TestHostDisplayValueComponent>;
 

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -698,54 +698,6 @@ describe('DisplayEditComponent', () => {
 
   });
 
-  describe('methods getValueType and isReadOnly', () => {
-    let hostCompDe;
-    let displayEditComponentDe;
-    let valueService;
-
-    beforeEach(() => {
-      testHostComponent.assignValue('http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger');
-      testHostFixture.detectChanges();
-
-      expect(testHostComponent.displayEditValueComponent).toBeTruthy();
-
-      hostCompDe = testHostFixture.debugElement;
-      displayEditComponentDe = hostCompDe.query(By.directive(DisplayEditComponent));
-
-      valueService = TestBed.inject(ValueService);
-
-    });
-
-    it('should return the type of a integer value as not readonly', () => {
-      expect(valueService.getValueTypeOrClass(testHostComponent.displayEditValueComponent.displayValue)).toEqual(Constants.IntValue);
-
-      expect(valueService.isReadOnly(Constants.IntValue, testHostComponent.displayEditValueComponent.displayValue)).toBe(false);
-    });
-
-    it('should return the class of a html text value as readonly', () => {
-
-      const htmlTextVal = new ReadTextValueAsHtml();
-      htmlTextVal.type = Constants.TextValue;
-
-      expect(valueService.getValueTypeOrClass(htmlTextVal)).toEqual('ReadTextValueAsHtml');
-
-      expect(valueService.isReadOnly('ReadTextValueAsHtml', htmlTextVal)).toBe(true);
-
-    });
-
-    it('should return the type of a plain text value as not readonly', () => {
-
-      const plainTextVal = new ReadTextValueAsString();
-      plainTextVal.type = Constants.TextValue;
-
-      expect(valueService.getValueTypeOrClass(plainTextVal)).toEqual('ReadTextValueAsString');
-
-      expect(valueService.isReadOnly('ReadTextValueAsString', plainTextVal)).toBe(false);
-
-    });
-
-  });
-
   describe('change from display to edit mode', () => {
     let hostCompDe;
     let displayEditComponentDe;

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.spec.ts
@@ -517,6 +517,7 @@ describe('DisplayEditComponent', () => {
 
       const inputVal: ReadTextValueAsHtml = new ReadTextValueAsHtml();
 
+      inputVal.property = 'http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext';
       inputVal.hasPermissions = 'CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser';
       inputVal.userHasPermission = 'CR';
       inputVal.type = 'http://api.knora.org/ontology/knora-api/v2#TextValue';

--- a/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/operations/display-edit/display-edit.component.ts
@@ -12,6 +12,7 @@ import {
     ReadResource,
     ReadUser,
     ReadValue,
+    ResourcePropertyDefinition,
     UpdateResource,
     UpdateValue,
     WriteValueResponse
@@ -114,7 +115,7 @@ export class DisplayEditComponent implements OnInit {
         private _valueOperationEventService: ValueOperationEventService,
         private _dialog: MatDialog,
         private _userService: UserService,
-        private _valueService: ValueService,) {
+        private _valueService: ValueService) {
     }
 
     ngOnInit() {
@@ -134,7 +135,17 @@ export class DisplayEditComponent implements OnInit {
 
         this.valueTypeOrClass = this._valueService.getValueTypeOrClass(this.displayValue);
 
-        this.readOnlyValue = this._valueService.isReadOnly(this.valueTypeOrClass, this.displayValue);
+        // get the resource property definition
+        const resPropDef = this.parentResource.entityInfo.getPropertyDefinitionsByType(ResourcePropertyDefinition).filter(
+            (propDef: ResourcePropertyDefinition) => propDef.id === this.displayValue.property
+        );
+
+        if (resPropDef.length !== 1) {
+            // this should never happen because we always have the property info for the given value
+            throw new Error('Resource Property Definition could not be found: ' + this.displayValue.property);
+        }
+
+        this.readOnlyValue = this._valueService.isReadOnly(this.valueTypeOrClass, this.displayValue, resPropDef[0]);
 
         // prevent getting info about system user (standoff link values are managed by the system)
         if (this.displayValue.attachedToUser !== 'http://www.knora.org/ontology/knora-admin#SystemUser') {

--- a/projects/dsp-ui/src/lib/viewer/services/value.service.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/services/value.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import {
     KnoraDate, KnoraPeriod,
     MockResource, ReadDateValue,
-    ReadIntValue,
+    ReadIntValue, ReadLinkValue,
     ReadTextValueAsHtml,
     ReadTextValueAsString,
     ReadTextValueAsXml,
@@ -172,6 +172,17 @@ describe('ValueService', () => {
 
             const valueClass = service.getValueTypeOrClass(readTextValueAsXml);
             expect(service.isReadOnly(valueClass, readTextValueAsXml, resPropDef)).toBeTruthy();
+        });
+
+        it('should mark a standoff link value as ReadOnly', () => {
+            const readStandoffLinkValue = new ReadLinkValue();
+            readStandoffLinkValue.type = 'http://api.knora.org/ontology/knora-api/v2#LinkValue';
+
+            const resPropDef = new ResourcePropertyDefinition();
+            resPropDef.isEditable = false;
+
+            const valueClass = service.getValueTypeOrClass(readStandoffLinkValue);
+            expect(service.isReadOnly(valueClass, readStandoffLinkValue, resPropDef)).toBeTruthy();
         });
 
         it('should mark ReadDateValue with unsupported era as ReadOnly', done => {

--- a/projects/dsp-ui/src/lib/viewer/services/value.service.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/services/value.service.spec.ts
@@ -115,6 +115,19 @@ describe('ValueService', () => {
 
     describe('isReadOnly', () => {
 
+        it('should not mark a ReadIntValue as ReadOnly', () => {
+
+            const readIntValue = new ReadIntValue();
+            readIntValue.type = 'http://api.knora.org/ontology/knora-api/v2#IntValue';
+
+            const resPropDef = new ResourcePropertyDefinition();
+            resPropDef.isEditable = true;
+
+            const valueClass = service.getValueTypeOrClass(readIntValue);
+            expect(service.isReadOnly(valueClass, readIntValue, resPropDef)).toBeFalsy();
+
+        });
+
         it('should not mark ReadTextValueAsString as ReadOnly', () => {
             const readTextValueAsString = new ReadTextValueAsString();
             readTextValueAsString.type = 'http://api.knora.org/ontology/knora-api/v2#TextValue';

--- a/projects/dsp-ui/src/lib/viewer/services/value.service.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/services/value.service.spec.ts
@@ -6,7 +6,8 @@ import {
     ReadIntValue,
     ReadTextValueAsHtml,
     ReadTextValueAsString,
-    ReadTextValueAsXml
+    ReadTextValueAsXml,
+    ResourcePropertyDefinition
 } from '@dasch-swiss/dsp-js';
 import { ValueService } from './value.service';
 
@@ -117,31 +118,47 @@ describe('ValueService', () => {
         it('should not mark ReadTextValueAsString as ReadOnly', () => {
             const readTextValueAsString = new ReadTextValueAsString();
             readTextValueAsString.type = 'http://api.knora.org/ontology/knora-api/v2#TextValue';
+
+            const resPropDef = new ResourcePropertyDefinition();
+            resPropDef.isEditable = true;
+
             const valueClass = service.getValueTypeOrClass(readTextValueAsString);
-            expect(service.isReadOnly(valueClass, readTextValueAsString)).toBeFalsy();
+            expect(service.isReadOnly(valueClass, readTextValueAsString, resPropDef)).toBeFalsy();
         });
 
         it('should mark ReadTextValueAsHtml as ReadOnly', () => {
             const readTextValueAsHtml = new ReadTextValueAsHtml();
             readTextValueAsHtml.type = 'http://api.knora.org/ontology/knora-api/v2#TextValue';
+
+            const resPropDef = new ResourcePropertyDefinition();
+            resPropDef.isEditable = true;
+
             const valueClass = service.getValueTypeOrClass(readTextValueAsHtml);
-            expect(service.isReadOnly(valueClass, readTextValueAsHtml)).toBeTruthy();
+            expect(service.isReadOnly(valueClass, readTextValueAsHtml, resPropDef)).toBeTruthy();
         });
 
         it('should not mark ReadTextValueAsXml with standard mapping as ReadOnly', () => {
             const readTextValueAsXml = new ReadTextValueAsXml();
             readTextValueAsXml.type = 'http://api.knora.org/ontology/knora-api/v2#TextValue';
             readTextValueAsXml.mapping = 'http://rdfh.ch/standoff/mappings/StandardMapping';
+
+            const resPropDef = new ResourcePropertyDefinition();
+            resPropDef.isEditable = true;
+
             const valueClass = service.getValueTypeOrClass(readTextValueAsXml);
-            expect(service.isReadOnly(valueClass, readTextValueAsXml)).toBeFalsy();
+            expect(service.isReadOnly(valueClass, readTextValueAsXml, resPropDef)).toBeFalsy();
         });
 
         it('should mark ReadTextValueAsXml with custom mapping as ReadOnly', () => {
             const readTextValueAsXml = new ReadTextValueAsXml();
             readTextValueAsXml.type = 'http://api.knora.org/ontology/knora-api/v2#TextValue';
             readTextValueAsXml.mapping = 'http://rdfh.ch/standoff/mappings/CustomMapping';
+
+            const resPropDef = new ResourcePropertyDefinition();
+            resPropDef.isEditable = true;
+
             const valueClass = service.getValueTypeOrClass(readTextValueAsXml);
-            expect(service.isReadOnly(valueClass, readTextValueAsXml)).toBeTruthy();
+            expect(service.isReadOnly(valueClass, readTextValueAsXml, resPropDef)).toBeTruthy();
         });
 
         it('should mark ReadDateValue with unsupported era as ReadOnly', done => {
@@ -152,8 +169,11 @@ describe('ValueService', () => {
 
                 date.date = new KnoraDate('GREGORIAN', 'BCE', 2019, 5, 13);
 
+                const resPropDef = new ResourcePropertyDefinition();
+                resPropDef.isEditable = true;
+
                 const valueClass = service.getValueTypeOrClass(date);
-                expect(service.isReadOnly(valueClass, date)).toBeTruthy();
+                expect(service.isReadOnly(valueClass, date, resPropDef)).toBeTruthy();
 
                 done();
 
@@ -169,8 +189,11 @@ describe('ValueService', () => {
 
                 date.date = new KnoraDate('GREGORIAN', 'CE', 2019, 5, 13);
 
+                const resPropDef = new ResourcePropertyDefinition();
+                resPropDef.isEditable = true;
+
                 const valueClass = service.getValueTypeOrClass(date);
-                expect(service.isReadOnly(valueClass, date)).toBeFalsy();
+                expect(service.isReadOnly(valueClass, date, resPropDef)).toBeFalsy();
 
                 done();
 
@@ -186,8 +209,11 @@ describe('ValueService', () => {
 
                 date.date = new KnoraDate('GREGORIAN', 'CE', 2019, 5);
 
+                const resPropDef = new ResourcePropertyDefinition();
+                resPropDef.isEditable = true;
+
                 const valueClass = service.getValueTypeOrClass(date);
-                expect(service.isReadOnly(valueClass, date)).toBeTruthy();
+                expect(service.isReadOnly(valueClass, date, resPropDef)).toBeTruthy();
 
                 done();
 
@@ -203,8 +229,11 @@ describe('ValueService', () => {
 
                 date.date = new KnoraDate('GREGORIAN', 'CE', 2019, 5, 1);
 
+                const resPropDef = new ResourcePropertyDefinition();
+                resPropDef.isEditable = true;
+
                 const valueClass = service.getValueTypeOrClass(date);
-                expect(service.isReadOnly(valueClass, date)).toBeFalsy();
+                expect(service.isReadOnly(valueClass, date, resPropDef)).toBeFalsy();
 
                 done();
 

--- a/projects/dsp-ui/src/lib/viewer/services/value.service.ts
+++ b/projects/dsp-ui/src/lib/viewer/services/value.service.ts
@@ -133,8 +133,16 @@ export class ValueService {
      *
      * @param valueTypeOrClass the type or class of the given value.
      * @param value the given value.
+     * @param propertyDef the given values property definition.
      */
-    isReadOnly(valueTypeOrClass: string, value: ReadValue): boolean {
+    isReadOnly(valueTypeOrClass: string, value: ReadValue, propertyDef: ResourcePropertyDefinition): boolean {
+
+        // if value is not editable in general from the ontology,
+        // flag it as read-only
+        if (!propertyDef.isEditable) {
+            return true;
+        }
+
         // only texts complying with the standard mapping can be edited using CKEditor.
         const xmlValueNonStandardMapping
             = valueTypeOrClass === this._readTextValueAsXml

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.spec.ts
@@ -317,6 +317,37 @@ describe('PropertyViewComponent', () => {
             expect(propertyViewComponentDe.query(By.css('.add-value'))).toBeDefined();
 
         });
+
+        it('should determine that adding a standoff link value is not allowed', () => {
+
+            const standoffLinkVal = testHostComponent.propArray.filter(
+                propVal => propVal.propDef.id === 'http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue'
+            );
+
+            expect(testHostComponent.propertyViewComponent.addValueIsAllowed(standoffLinkVal[0])).toBeFalsy();
+
+        });
+
+        it('should determine that adding a incoming link value is not allowed', () => {
+
+            const standoffLinkVal = testHostComponent.propArray.filter(
+                propVal => propVal.propDef.id === 'http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue'
+            );
+
+            expect(testHostComponent.propertyViewComponent.addValueIsAllowed(standoffLinkVal[0])).toBeFalsy();
+
+        });
+
+        it('should determine that adding an int value is allowed', () => {
+
+            const standoffLinkVal = testHostComponent.propArray.filter(
+                propVal => propVal.propDef.id === 'http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger'
+            );
+
+            expect(testHostComponent.propertyViewComponent.addValueIsAllowed(standoffLinkVal[0])).toBeTruthy();
+
+        });
+
     });
 
 });

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.spec.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.spec.ts
@@ -281,17 +281,21 @@ describe('PropertyViewComponent', () => {
 
             let addButtons = propertyViewComponentDe.queryAll(By.css('button.create'));
 
-            // current amount of buttons should equal 19 because the boolean property shouldn't have an add button if it has a value
-            expect(addButtons.length).toEqual(19);
+            // current amount of buttons should equal 17
+            // because the boolean property shouldn't have an add button if it has a value
+            // standoff links value and has incoming link value are system props and cannot be added: -2
+            expect(addButtons.length).toEqual(17);
 
             // remove value from the boolean property
             testHostComponent.propArray[9].values = [];
 
             testHostFixture.detectChanges();
 
-            // now the boolean property should have an add button so the amount of add buttons on the page should increase by 1
+            // now the boolean property should have an add button
+            // so the amount of add buttons on the page should increase by 1
+            // standoff links value and has incoming link value are system props and cannot be added: -2
             addButtons = propertyViewComponentDe.queryAll(By.css('button.create'));
-            expect(addButtons.length).toEqual(20);
+            expect(addButtons.length).toEqual(18);
 
         });
 

--- a/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.ts
+++ b/projects/dsp-ui/src/lib/viewer/views/property-view/property-view.component.ts
@@ -11,6 +11,7 @@ import {
     PermissionUtil,
     ReadLinkValue,
     ReadResource,
+    ResourcePropertyDefinition,
     SystemPropertyDefinition
 } from '@dasch-swiss/dsp-js';
 import { Subscription } from 'rxjs';
@@ -102,7 +103,7 @@ export class PropertyViewComponent implements OnInit, OnDestroy {
     /**
      * Called from the template when the user clicks on the cancel button
      */
-    hideAddValueForm() {
+    hideAddValueForm() {
         this.addValueFormIsVisible = false;
         this.addButtonIsVisible = true;
         this.propID = undefined;
@@ -114,11 +115,12 @@ export class PropertyViewComponent implements OnInit, OnDestroy {
      * @param prop the resource property
      */
     addValueIsAllowed(prop: PropertyInfoValues): boolean {
-        // temporary until CkEditor is integrated
-        // const guiElement = (prop.propDef as ResourcePropertyDefinition).guiElement;
-        // if (guiElement === 'http://api.knora.org/ontology/salsah-gui/v2#Richtext') {
-        //     return false;
-        // }
+
+        // if the ontology flags this as a read-only property,
+        // don't ever allow to add a value
+        if (prop.propDef instanceof ResourcePropertyDefinition && !prop.propDef.isEditable) {
+           return false;
+        }
 
         const isAllowed = CardinalityUtil.createValueForPropertyAllowed(
             prop.propDef.id, prop.values.length, this.parentResource.entityInfo.classes[this.parentResource.type]);


### PR DESCRIPTION
resolves DSP-974 and DSP-1043

`ValueService.isReadOnly` has an additional third argument now: `propertyDef: ResourcePropertyDefinition`.
I added the flag "breaking" because this method could be used directly by the app.