### PR TITLE
DSP-1132 Advanced search limit to project

### DIFF
--- a/projects/dsp-ui/src/lib/search/advanced-search/advanced-search.component.ts
+++ b/projects/dsp-ui/src/lib/search/advanced-search/advanced-search.component.ts
@@ -3,7 +3,6 @@ import {
     EventEmitter,
     Inject,
     Input,
-    OnChanges,
     OnDestroy,
     OnInit,
     Output,

--- a/projects/dsp-ui/src/lib/search/advanced-search/advanced-search.component.ts
+++ b/projects/dsp-ui/src/lib/search/advanced-search/advanced-search.component.ts
@@ -2,6 +2,8 @@ import {
     Component,
     EventEmitter,
     Inject,
+    Input,
+    OnChanges,
     OnDestroy,
     OnInit,
     Output,
@@ -42,6 +44,13 @@ const typeGuard = <T>(o: any, className: Constructor<T>): o is T => {
     styleUrls: ['./advanced-search.component.scss']
 })
 export class AdvancedSearchComponent implements OnInit, OnDestroy {
+
+    /**
+     * Filter ontologies by specified project IRI
+     *
+     * @param limitToProject
+     */
+    @Input() limitToProject?: string;
 
     /**
      * The data event emitter of type SearchParams
@@ -94,7 +103,6 @@ export class AdvancedSearchComponent implements OnInit, OnDestroy {
         this.formChangesSubscription = this.form.statusChanges.subscribe((data) => {
             this.formValid = this._validateForm();
         });
-
         // initialize ontologies to be used for the ontologies selection in the search form
         this.initializeOntologies();
     }
@@ -129,17 +137,34 @@ export class AdvancedSearchComponent implements OnInit, OnDestroy {
      * @returns void
      */
     initializeOntologies(): void {
-        this._dspApiConnection.v2.onto.getOntologiesMetadata().subscribe(
-            (response: OntologiesMetadata) => {
-                // filter out system ontologies
-                response.ontologies = response.ontologies.filter(onto => onto.attachedToProject !== Constants.SystemProjectIRI);
 
-                this.ontologiesMetadata = response;
-            },
-            (error: ApiResponseError) => {
-                this._notification.openSnackBar(error);
-                this.errorMessage = error;
-            });
+        if (this.limitToProject) {
+            this._dspApiConnection.v2.onto.getOntologiesByProjectIri(this.limitToProject).subscribe(
+                (response: OntologiesMetadata) => {
+                    // filter out system ontologies
+                    response.ontologies = response.ontologies.filter(onto => onto.attachedToProject !== Constants.SystemProjectIRI);
+
+                    this.ontologiesMetadata = response;
+                },
+                (error: ApiResponseError) => {
+                    this._notification.openSnackBar(error);
+                    this.errorMessage = error;
+                });
+        } else {
+            this._dspApiConnection.v2.onto.getOntologiesMetadata().subscribe(
+                (response: OntologiesMetadata) => {
+                    // filter out system ontologies
+                    response.ontologies = response.ontologies.filter(onto => onto.attachedToProject !== Constants.SystemProjectIRI);
+
+                    this.ontologiesMetadata = response;
+                },
+                (error: ApiResponseError) => {
+                    this._notification.openSnackBar(error);
+                    this.errorMessage = error;
+                });
+        }
+
+
     }
 
     /**

--- a/projects/dsp-ui/src/lib/search/fulltext-search/fulltext-search.component.spec.ts
+++ b/projects/dsp-ui/src/lib/search/fulltext-search/fulltext-search.component.spec.ts
@@ -25,7 +25,7 @@ import { FulltextSearchComponent } from './fulltext-search.component';
     template: `
         <dsp-fulltext-search #fulltextSearch
             [projectfilter]="projectfilter"
-            [filterbyproject]="filterbyproject">
+            [limitToProject]="limitToProject">
         </dsp-fulltext-search>
     `
 })
@@ -36,7 +36,8 @@ class TestHostFulltextSearchComponent implements OnInit {
     sortingService: SortingService = new SortingService();
 
     projectfilter?: boolean = true;
-    filterbyproject?: string;
+
+    limitToProject?: string;
 
     ngOnInit() {
     }

--- a/projects/dsp-ui/src/lib/search/fulltext-search/fulltext-search.component.ts
+++ b/projects/dsp-ui/src/lib/search/fulltext-search/fulltext-search.component.ts
@@ -34,12 +34,14 @@ export interface PrevSearchItem {
     query: string;
 }
 
+const resolvedPromise = Promise.resolve(null);
+
 @Component({
     selector: 'dsp-fulltext-search',
     templateUrl: './fulltext-search.component.html',
     styleUrls: ['./fulltext-search.component.scss']
 })
-export class FulltextSearchComponent implements OnInit {
+export class FulltextSearchComponent implements OnInit, OnChanges {
 
     /**
      *
@@ -147,15 +149,25 @@ export class FulltextSearchComponent implements OnInit {
             this.getProject(this.limitToProject);
         }
 
-        if (this.projectfilter) {
-            this.getAllProjects();
 
-            if (localStorage.getItem('currentProject') !== null) {
-                this.setProject(
-                    JSON.parse(localStorage.getItem('currentProject'))
-                );
-            }
-        }
+    }
+
+    ngOnChanges() {
+        // resource classes have been reinitialized
+            // reset form
+            resolvedPromise.then(() => {
+
+                if (this.projectfilter) {
+                    this.getAllProjects();
+
+                    if (localStorage.getItem('currentProject') !== null) {
+                        this.setProject(
+                            JSON.parse(localStorage.getItem('currentProject'))
+                        );
+                    }
+                }
+
+            });
     }
 
     /**

--- a/projects/dsp-ui/src/lib/search/fulltext-search/fulltext-search.component.ts
+++ b/projects/dsp-ui/src/lib/search/fulltext-search/fulltext-search.component.ts
@@ -149,7 +149,9 @@ export class FulltextSearchComponent implements OnInit, OnChanges {
             this.getProject(this.limitToProject);
         }
 
-
+        if (this.projectfilter) {
+            this.getAllProjects();
+        }
     }
 
     ngOnChanges() {
@@ -157,14 +159,10 @@ export class FulltextSearchComponent implements OnInit, OnChanges {
             // reset form
             resolvedPromise.then(() => {
 
-                if (this.projectfilter) {
-                    this.getAllProjects();
-
-                    if (localStorage.getItem('currentProject') !== null) {
-                        this.setProject(
-                            JSON.parse(localStorage.getItem('currentProject'))
-                        );
-                    }
+                if (localStorage.getItem('currentProject') !== null) {
+                    this.setProject(
+                        JSON.parse(localStorage.getItem('currentProject'))
+                    );
                 }
 
             });

--- a/projects/dsp-ui/src/lib/search/search-panel/search-panel.component.html
+++ b/projects/dsp-ui/src/lib/search/search-panel/search-panel.component.html
@@ -1,6 +1,8 @@
 <div class="dsp-search-panel" #fullSearchPanel cdkOverlayOrigin>
 
-    <dsp-fulltext-search [projectfilter]="projectfilter" [filterbyproject]="filterbyproject"
+    <dsp-fulltext-search
+        [projectfilter]="projectfilter"
+        [(limitToProject)]="limitToProject"
         (search)="emitSearch($event)">
     </dsp-fulltext-search>
 
@@ -33,7 +35,7 @@
             </span>
         </div>
         <div class="dsp-menu-content">
-            <dsp-advanced-search *ngIf="showAdvanced" (search)="emitSearch($event)"></dsp-advanced-search>
+            <dsp-advanced-search *ngIf="showAdvanced" [limitToProject]="limitToProject" (search)="emitSearch($event)"></dsp-advanced-search>
             <dsp-expert-search *ngIf="!showAdvanced" (search)="emitSearch($event)"></dsp-expert-search>
         </div>
     </div>

--- a/projects/dsp-ui/src/lib/search/search-panel/search-panel.component.spec.ts
+++ b/projects/dsp-ui/src/lib/search/search-panel/search-panel.component.spec.ts
@@ -13,7 +13,7 @@ import { SearchPanelComponent } from './search-panel.component';
 class TestFulltextSearchComponent implements OnInit {
 
     @Input() projectfilter?: boolean = false;
-    @Input() filterbyproject?: string;
+    @Input() limitToProject?: string;
     @Input() show: boolean;
     @Output() showState = new EventEmitter();
 

--- a/projects/dsp-ui/src/lib/search/search-panel/search-panel.component.ts
+++ b/projects/dsp-ui/src/lib/search/search-panel/search-panel.component.ts
@@ -1,6 +1,15 @@
 import { ConnectionPositionPair, Overlay, OverlayConfig, OverlayRef, PositionStrategy } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
-import { AfterContentInit, AfterViewInit, Component, ElementRef, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild, ViewContainerRef } from '@angular/core';
+import {
+    Component,
+    ElementRef,
+    EventEmitter,
+    Input, OnInit,
+    Output,
+    TemplateRef,
+    ViewChild,
+    ViewContainerRef
+} from '@angular/core';
 import { SearchParams } from '../../viewer/views/list-view/list-view.component';
 
 @Component({
@@ -8,7 +17,7 @@ import { SearchParams } from '../../viewer/views/list-view/list-view.component';
     templateUrl: './search-panel.component.html',
     styleUrls: ['./search-panel.component.scss']
 })
-export class SearchPanelComponent implements OnInit, AfterViewInit {
+export class SearchPanelComponent implements OnInit {
 
     /**
      * @param [projectfilter] If true it shows the selection of projects to filter by one of them
@@ -68,11 +77,6 @@ export class SearchPanelComponent implements OnInit, AfterViewInit {
         if (this.filterbyproject) {
             this.limitToProject = this.filterbyproject;
         }
-        console.log('OnInit', this.limitToProject);
-    }
-
-    ngAfterViewInit() {
-        console.log('AfterViewInit', this.limitToProject);
     }
 
     openPanelWithBackdrop(type: string) {
@@ -109,7 +113,6 @@ export class SearchPanelComponent implements OnInit, AfterViewInit {
     }
 
     updateLimitToProject(id: string) {
-        console.log('updateLimitToProject', id);
         this.limitToProject = id;
     }
 
@@ -129,7 +132,7 @@ export class SearchPanelComponent implements OnInit, AfterViewInit {
     closeMenu(): void {
         this.showAdvanced = false;
         this.showExpert = false;
-        if(this.overlayRef) {
+        if (this.overlayRef) {
             this.overlayRef.detach();
         }
     }

--- a/projects/dsp-ui/src/lib/search/search-panel/search-panel.component.ts
+++ b/projects/dsp-ui/src/lib/search/search-panel/search-panel.component.ts
@@ -1,6 +1,6 @@
 import { ConnectionPositionPair, Overlay, OverlayConfig, OverlayRef, PositionStrategy } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
-import { Component, ElementRef, EventEmitter, Input, Output, TemplateRef, ViewChild, ViewContainerRef } from '@angular/core';
+import { AfterContentInit, AfterViewInit, Component, ElementRef, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild, ViewContainerRef } from '@angular/core';
 import { SearchParams } from '../../viewer/views/list-view/list-view.component';
 
 @Component({
@@ -8,7 +8,7 @@ import { SearchParams } from '../../viewer/views/list-view/list-view.component';
     templateUrl: './search-panel.component.html',
     styleUrls: ['./search-panel.component.scss']
 })
-export class SearchPanelComponent {
+export class SearchPanelComponent implements OnInit, AfterViewInit {
 
     /**
      * @param [projectfilter] If true it shows the selection of projects to filter by one of them
@@ -16,10 +16,19 @@ export class SearchPanelComponent {
     @Input() projectfilter?: boolean = false;
 
     /**
+     * @deprecated Use `limitToProject` instead
+     *
      * @param [filterbyproject] If your full-text search should be filtered by one project, you can define it with project
      * iri in the parameter filterbyproject.
      */
     @Input() filterbyproject?: string;
+
+    /**
+     * Filter ontologies in advanced search or query in fulltext search by specified project IRI
+     *
+     * @param limitToProject
+     */
+    @Input() limitToProject?: string;
 
     /**
      * @param [advanced] Adds the extended / advanced search to the panel
@@ -54,6 +63,18 @@ export class SearchPanelComponent {
         private _viewContainerRef: ViewContainerRef
     ) { }
 
+    ngOnInit() {
+        // filterbyproject is set as deprecated. To avoid breaking changes we still support the parameter
+        if (this.filterbyproject) {
+            this.limitToProject = this.filterbyproject;
+        }
+        console.log('OnInit', this.limitToProject);
+    }
+
+    ngAfterViewInit() {
+        console.log('AfterViewInit', this.limitToProject);
+    }
+
     openPanelWithBackdrop(type: string) {
 
         this.showAdvanced = (type === 'advanced');
@@ -85,6 +106,11 @@ export class SearchPanelComponent {
         const overlayPosition = this._overlay.position().flexibleConnectedTo(this.searchPanel).withPositions(positions).withLockedPosition(false);
 
         return overlayPosition;
+    }
+
+    updateLimitToProject(id: string) {
+        console.log('updateLimitToProject', id);
+        this.limitToProject = id;
     }
 
     /**

--- a/projects/dsp-ui/src/lib/search/search-panel/search-panel.component.ts
+++ b/projects/dsp-ui/src/lib/search/search-panel/search-panel.component.ts
@@ -21,6 +21,7 @@ export class SearchPanelComponent implements OnInit {
 
     /**
      * @param [projectfilter] If true it shows the selection of projects to filter by one of them
+     * Default value: false
      */
     @Input() projectfilter?: boolean = false;
 
@@ -41,11 +42,13 @@ export class SearchPanelComponent implements OnInit {
 
     /**
      * @param [advanced] Adds the extended / advanced search to the panel
+     * Default value: false
      */
     @Input() advanced?: boolean = false;
 
     /**
      * @param [expert] Adds the expert search / gravsearch editor to the panel
+     * Default value: false
      */
     @Input() expert?: boolean = false;
 

--- a/src/app/search-playground/search-playground.component.html
+++ b/src/app/search-playground/search-playground.component.html
@@ -58,7 +58,7 @@ Select the component to play with:
                 </mat-expansion-panel-header>
                 <pre>
       &lt;dsp-search-panel
-        [filterbyproject]="{{limitToProject}}"
+        [limitToProject]="{{limitToProject}}"
         [projectfilter]="{{projectFilter}}"
         [advanced]="{{advancedSearch}}"
         [expert]="{{expertSearch}}"
@@ -73,7 +73,7 @@ Select the component to play with:
             <!-- simulate header -->
             <div class="header">
                 <dsp-search-panel *ngIf="!loading" class="center" [projectfilter]="projectFilter"
-                    [filterbyproject]="limitToProject" [advanced]="advancedSearch" [expert]="expertSearch" (search)="doSearch($event)">
+                    [limitToProject]="limitToProject" [advanced]="advancedSearch" [expert]="expertSearch" (search)="doSearch($event)">
                 </dsp-search-panel>
                 <!--  -->
 


### PR DESCRIPTION
resolves DSP-1132

In this PR I added `limitToProject` parameter to advanced search. It can be used in project specific apps to list project specific ontologies only.

`limitToProject` can be used in advanced-search, in fulltext-search and in search-panel which is a combination of advanced- and fulltext-search. ~~But at the moment I have an issue with communication between the three components.~~

~~In case of `projectFilter = true` it shows a dropdown menu as part of fulltext-search to select a project. When I select a project it emits the data from fulltext-search to parent, in this case `search-panel`. limitToProject is a two-way-binding object of fulltext-search. But it ends in an `ExpressionChangedAfterItHasBeenCheckedError` in case a project is already selected when page refreshs (onInit).~~

![Screen Shot 2020-12-02 at 15 28 15](https://user-images.githubusercontent.com/4253580/100890525-a44bf400-34b8-11eb-8b8f-37c8d18105d2.png)
**Issue solved in 9e62026**

Additional to this fix I set `filterbyproject` parameter in fulltext-search and in search-panel as deprecated. It's replaced by `limitToProject` parameter to keep it consistent. `filterbyproject` was confusing anyway, besides `projectfilter` parameter.

You can play around with the parameters in the search playground: <http://localhost:4200/search>