### PR TITLE
Prepare release 1.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           release-type: node
-          package-name: DSP-JS
+          package-name: "@dasch-swiss/dsp-ui"
           changelog-types: '[{"type": "feat","section": "Enhancements","hidden": false }, {"type": "fix","section": "Bug Fixes","hidden": false }, {"type": "chore","section": "Maintenance","hidden": false }, {"type": "docs","section": "Documentation","hidden": false }]'
 
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,182 @@
+# Changelog
+
+## v1.0.0 (17/12/2020)
+
+#### Breaking changes
+
+- [#82](https://github.com/dasch-swiss/dsp-ui-lib/pull/82) Action module pipes migration
+- [#214](https://github.com/dasch-swiss/dsp-ui-lib/pull/214) DSP-759 Check if a Given Date Can Be Edited / Rename ValueTypeService to ValueService
+- [#233](https://github.com/dasch-swiss/dsp-ui-lib/pull/233) DSP-974 / DSP-1043 Determine from ontology if a property is read-only
+- [#228](https://github.com/dasch-swiss/dsp-ui-lib/pull/228) DSP-1002 Update standoff link value
+- [#199](https://github.com/dasch-swiss/dsp-ui-lib/pull/199) DSP-682 Integrate Ckeditor into Property View
+- [#137](https://github.com/dasch-swiss/dsp-ui-lib/pull/137) Better data handling in search module components
+- [#78](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/78) Rename @knora/ui to @dasch-swiss/dsp-ui and kui to dsp
+- [#63](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/63) Upgrade to Angular 9
+
+#### Enhancements
+
+- [#138](https://github.com/dasch-swiss/dsp-ui-lib/pull/138) Optimise the number of cards per line
+- [#136](https://github.com/dasch-swiss/dsp-ui-lib/pull/136) Build lib including assets folder
+- [#128](https://github.com/dasch-swiss/dsp-ui-lib/pull/128) Add Still Image Viewer
+- [#125](https://github.com/dasch-swiss/dsp-ui-lib/pull/125) Login Form Migration
+- [#122](https://github.com/dasch-swiss/dsp-ui-lib/pull/122) Simple list of resources
+- [#109](https://github.com/dasch-swiss/dsp-ui-lib/pull/109) Create new value for existing property
+- [#119](https://github.com/dasch-swiss/dsp-ui-lib/pull/119) Add Gravsearch Generation Service
+- [#107](https://github.com/dasch-swiss/dsp-ui-lib/pull/107) Migrate Advanced Search
+- [#116](https://github.com/dasch-swiss/dsp-ui-lib/pull/116) Add ArkUrl copy to clipboard in resource-view
+- [#115](https://github.com/dasch-swiss/dsp-ui-lib/pull/115) DSP-UI Live Reloading
+- [#105](https://github.com/dasch-swiss/dsp-ui-lib/pull/105) Move the search-panel and the fulltext-search components
+- [#112](https://github.com/dasch-swiss/dsp-ui-lib/pull/112) Use latest rc of dsp-js and other improvements
+- [#111](https://github.com/dasch-swiss/dsp-ui-lib/pull/111) Make the sorting service more flexible
+- [#100](https://github.com/dasch-swiss/dsp-ui-lib/pull/100) Use strictTemplates Compiler Option
+- [#103](https://github.com/dasch-swiss/dsp-ui-lib/pull/103) Search module setup
+- [#88](https://github.com/dasch-swiss/dsp-ui-lib/pull/88) Refactor how to get properties by type
+- [#73](https://github.com/dasch-swiss/dsp-ui-lib/pull/73) Custom Boolean Pipe
+- [#238](https://github.com/dasch-swiss/dsp-ui-lib/pull/238) DSP-1132 Advanced search limit to project
+- [#220](https://github.com/dasch-swiss/dsp-ui-lib/pull/220) DSP-784 Propagate Click Event to Res Viewer Comp.
+- [#230](https://github.com/dasch-swiss/dsp-ui-lib/pull/230) DSP-945-update resource viewer
+- [#213](https://github.com/dasch-swiss/dsp-ui-lib/pull/213) DSP-869 add select project component
+- [#232](https://github.com/dasch-swiss/dsp-ui-lib/pull/232) Add missing decorator to ValueOperationEventService
+- [#239](https://github.com/dasch-swiss/dsp-ui-lib/pull/239) Use new methods for ontology info processing
+- [#227](https://github.com/dasch-swiss/dsp-ui-lib/pull/227) DSP-1028 Activate still-image in resource viewer
+- [#218](https://github.com/dasch-swiss/dsp-ui-lib/pull/218) DSP-904 upload form for representations
+- [#207](https://github.com/dasch-swiss/dsp-ui-lib/pull/207) DSP-806 Add the attribute 'rel' to uri and geoname value component template
+- [#217](https://github.com/dasch-swiss/dsp-ui-lib/pull/217) Create user service
+- [#134](https://github.com/dasch-swiss/dsp-ui-lib/pull/134) Add CKeditor
+- [#208](https://github.com/dasch-swiss/dsp-ui-lib/pull/208) DSP-762 Error handling and notification service
+- [#157](https://github.com/dasch-swiss/dsp-ui-lib/pull/157) DSP-369 System Prop Info
+- [#192](https://github.com/dasch-swiss/dsp-ui-lib/pull/192) DSP-653 Default Boolean Value
+- [#198](https://github.com/dasch-swiss/dsp-ui-lib/pull/198) DSP-638 Value Deletion Comment
+- [#202](https://github.com/dasch-swiss/dsp-ui-lib/pull/202) DSP-657 Handle links in XML text values
+- [#201](https://github.com/dasch-swiss/dsp-ui-lib/pull/201) DSP-779 Display error messages directly and not only in console
+- [#200](https://github.com/dasch-swiss/dsp-ui-lib/pull/200) DSP-777 Show message on all server errors in login component
+- [#189](https://github.com/dasch-swiss/dsp-ui-lib/pull/189) DSP-693 Sort button style
+- [#172](https://github.com/dasch-swiss/dsp-ui-lib/pull/172) Show label for URI Value (if set)
+- [#168](https://github.com/dasch-swiss/dsp-ui-lib/pull/168) Message component timer
+- [#161](https://github.com/dasch-swiss/dsp-ui-lib/pull/161) Read mode date value era and calendar
+- [#160](https://github.com/dasch-swiss/dsp-ui-lib/pull/160) Emit link value when clicked on
+- [#159](https://github.com/dasch-swiss/dsp-ui-lib/pull/159) Make URI values clickable
+- [#155](https://github.com/dasch-swiss/dsp-ui-lib/pull/155) Experimental: Alternative approach to resource/property view UI buttons
+- [#153](https://github.com/dasch-swiss/dsp-ui-lib/pull/153) Error handling: submitting duplicate values
+- [#152](https://github.com/dasch-swiss/dsp-ui-lib/pull/152) List of properties: refactor and redesign
+- [#147](https://github.com/dasch-swiss/dsp-ui-lib/pull/147) Delete property value
+- [#150](https://github.com/dasch-swiss/dsp-ui-lib/pull/150) Action Module Confirmation Dialog Component
+- [#149](https://github.com/dasch-swiss/dsp-ui-lib/pull/149) Export operator.ts
+- [#146](https://github.com/dasch-swiss/dsp-ui-lib/pull/146) Add missing regex variables
+- [#139](https://github.com/dasch-swiss/dsp-ui-lib/pull/139) Create New Value V2
+- [#83](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/83) Preparing Release Candidate v1.0.0-rc.0
+- [#67](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/67) Improve read mode appearance of value components
+- [#69](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/69) Create Value Comparison Method
+- [#57](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/57) Geoname mat-icon suffix
+- [#42](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/42) Prototyping property viewer with the value components
+- [#43](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/43) Value Component CSS and other styling
+- [#56](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/56) Simulate productive circumstances locally
+- [#34](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/34) Color value component
+- [#26](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/26) Interval Value Component
+- [#29](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/29) Boolean value component
+- [#22](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/22) Uri Value Component
+- [#23](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/23) Decimal Value Component
+
+#### Bug Fixes
+
+- [#142](https://github.com/dasch-swiss/dsp-ui-lib/pull/142) FIX: DSP UI is blocked when submitting an invalid value
+- [#121](https://github.com/dasch-swiss/dsp-ui-lib/pull/121) Flaky E2E Tests
+- [#118](https://github.com/dasch-swiss/dsp-ui-lib/pull/118) AppInitService: Make members non static
+- [#106](https://github.com/dasch-swiss/dsp-ui-lib/pull/106) FIX: display-edit dev build errors
+- [#104](https://github.com/dasch-swiss/dsp-ui-lib/pull/104) FIX: sublist value component viewchild issue
+- [#102](https://github.com/dasch-swiss/dsp-ui-lib/pull/102) FIX: Sort button type annotation
+- [#97](https://github.com/dasch-swiss/dsp-ui-lib/pull/97) FIX: Action Module Playground & Components Missing Imports
+- [#237](https://github.com/dasch-swiss/dsp-ui-lib/pull/237) DSP-1110 Bug fixes and styling improvement in resource viewer
+- [#224](https://github.com/dasch-swiss/dsp-ui-lib/pull/224) CKEditor Backward Compatibility
+- [#211](https://github.com/dasch-swiss/dsp-ui-lib/pull/211) DSP-885 default gravsearch query
+- [#229](https://github.com/dasch-swiss/dsp-ui-lib/pull/229) DSP-1075 Bug in notification service
+- [#221](https://github.com/dasch-swiss/dsp-ui-lib/pull/221) DSP-885 Fix default gravsearch query
+- [#222](https://github.com/dasch-swiss/dsp-ui-lib/pull/222) DSP-768 Styling issue in resource (properties) viewer
+- [#226](https://github.com/dasch-swiss/dsp-ui-lib/pull/226) DSP-924 Never Import from index.ts Internally
+- [#212](https://github.com/dasch-swiss/dsp-ui-lib/pull/212) DSP-788 Fix compatibility issues with CKEditor version 4
+- [#182](https://github.com/dasch-swiss/dsp-ui-lib/pull/182) DSP-652 FIX: Boolean add button
+- [#205](https://github.com/dasch-swiss/dsp-ui-lib/pull/205) DSP-674 Bug fix in search panel
+- [#194](https://github.com/dasch-swiss/dsp-ui-lib/pull/194) DSP-436 Fix workflow issue 
+- [#171](https://github.com/dasch-swiss/dsp-ui-lib/pull/171) FIX: Delete Value UI Bug
+- [#169](https://github.com/dasch-swiss/dsp-ui-lib/pull/169) Search Panel: Advanced Search Not Displayed
+- [#162](https://github.com/dasch-swiss/dsp-ui-lib/pull/162) Export GND directive
+- [#77](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/77) FIX: KnoraDatePipe return values
+- [#66](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/66) BUG: User can no longer save an edited value
+- [#58](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/58) Clean up prop label
+
+#### Documentation
+
+- [#99](https://github.com/dasch-swiss/dsp-ui-lib/pull/99) Update README
+- [#87](https://github.com/dasch-swiss/dsp-ui-lib/pull/87) Describe concept of value components
+- [#225](https://github.com/dasch-swiss/dsp-ui-lib/pull/225) Explain Demo App (Playground)
+- [#179](https://github.com/dasch-swiss/dsp-ui-lib/pull/179) docs: Update CHANGELOG
+- [#144](https://github.com/dasch-swiss/dsp-ui-lib/pull/144) Update CHANGELOG and READMEs
+- [#241](https://github.com/dasch-swiss/dsp-ui-lib/pull/241) Update CHANGELOG and READMEs
+- [#72](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/72) Step by step guidelines in the READMEs
+
+#### Styling
+
+- [#141](https://github.com/dasch-swiss/dsp-ui-lib/pull/141) Change Home Icon of OpenSeadragon Viewer
+- [#206](https://github.com/dasch-swiss/dsp-ui-lib/pull/206) DSP-522 Refactor search panel style
+- [#180](https://github.com/dasch-swiss/dsp-ui-lib/pull/180) DSP-636 Message Component Css
+- [#184](https://github.com/dasch-swiss/dsp-ui-lib/pull/184) DSP-615 Date Value Component Polish
+- [#185](https://github.com/dasch-swiss/dsp-ui-lib/pull/185) DSP-644 Date & Interval Components: Remove Parent Input Placeholder
+- [#191](https://github.com/dasch-swiss/dsp-ui-lib/pull/191) DSP-623 Color Value Polish
+- [#193](https://github.com/dasch-swiss/dsp-ui-lib/pull/193) DSP-651 Geoname Value Styling
+
+#### Dependencies
+
+- [#242](https://github.com/dasch-swiss/dsp-ui-lib/pull/242) Update dsp-js-lib
+- [#127](https://github.com/dasch-swiss/dsp-ui-lib/pull/127) Update JS-Lib Dep
+- [#236](https://github.com/dasch-swiss/dsp-ui-lib/pull/236) Update DSP dependencies
+- [#219](https://github.com/dasch-swiss/dsp-ui-lib/pull/219) Update dependencies
+- [#215](https://github.com/dasch-swiss/dsp-ui-lib/pull/215) Update dsp-js-lib
+- [#209](https://github.com/dasch-swiss/dsp-ui-lib/pull/209) Update DSP-JS-Lib
+- [#186](https://github.com/dasch-swiss/dsp-ui-lib/pull/186) DSP-672 Update dependency
+- [#177](https://github.com/dasch-swiss/dsp-ui-lib/pull/177) fix: Update peer dependencies for js-lib
+- [#166](https://github.com/dasch-swiss/dsp-ui-lib/pull/166) Update peer-dep for dsp-js lib
+- [#151](https://github.com/dasch-swiss/dsp-ui-lib/pull/151) Update dsp-js-lib to version 1.0.0-rc.6
+
+#### Maintenance
+
+- [#143](https://github.com/dasch-swiss/dsp-ui-lib/pull/143) Prerelease of v1.0.0 rc.2
+- [#131](https://github.com/dasch-swiss/dsp-ui-lib/pull/131) Migrate String Literal Input Component
+- [#135](https://github.com/dasch-swiss/dsp-ui-lib/pull/135) Rename knoraApiConnection to _dspApiConnection in constructors
+- [#133](https://github.com/dasch-swiss/dsp-ui-lib/pull/133) Update assets folder and file structrue
+- [#132](https://github.com/dasch-swiss/dsp-ui-lib/pull/132) Migrate Stringify String Literal Pipe
+- [#123](https://github.com/dasch-swiss/dsp-ui-lib/pull/123) Hide link to geonames.org in edit mode
+- [#113](https://github.com/dasch-swiss/dsp-ui-lib/pull/113) Update JS-Lib Dep
+- [#110](https://github.com/dasch-swiss/dsp-ui-lib/pull/110) Remove jdn-datepicker directive from action module directives
+- [#101](https://github.com/dasch-swiss/dsp-ui-lib/pull/101) Refactor Sort Button
+- [#95](https://github.com/dasch-swiss/dsp-ui-lib/pull/95) Migration of message component
+- [#94](https://github.com/dasch-swiss/dsp-ui-lib/pull/94) Migrate sort button
+- [#93](https://github.com/dasch-swiss/dsp-ui-lib/pull/93) Progress Indicator
+- [#91](https://github.com/dasch-swiss/dsp-ui-lib/pull/91) Migrate action module directives
+- [#92](https://github.com/dasch-swiss/dsp-ui-lib/pull/92) Update tslint 
+- [#89](https://github.com/dasch-swiss/dsp-ui-lib/pull/89) Refactor Truncate Pipe
+- [#86](https://github.com/dasch-swiss/dsp-ui-lib/pull/86) Update package information
+- [#231](https://github.com/dasch-swiss/dsp-ui-lib/pull/231) Adapt knora-api repo name
+- [#235](https://github.com/dasch-swiss/dsp-ui-lib/pull/235) Update to v13.0.0-rc.23
+- [#234](https://github.com/dasch-swiss/dsp-ui-lib/pull/234) DSP-1097 - Bump JS-Lib Version and Fix Breaking Changes
+- [#210](https://github.com/dasch-swiss/dsp-ui-lib/pull/210) DSP-881 Value Component Base Class Changes
+- [#216](https://github.com/dasch-swiss/dsp-ui-lib/pull/216) DSP-920 Renaming default github branch to "main"
+- [#187](https://github.com/dasch-swiss/dsp-ui-lib/pull/187) DSP-649 Hide Geometry Property
+- [#197](https://github.com/dasch-swiss/dsp-ui-lib/pull/197) DSP-708 Refactor CI workflow script
+- [#195](https://github.com/dasch-swiss/dsp-ui-lib/pull/195) DSP-701 Add template for PRs
+- [#183](https://github.com/dasch-swiss/dsp-ui-lib/pull/183) DSP-619 Update release process
+- [#175](https://github.com/dasch-swiss/dsp-ui-lib/pull/175) Fix compareObjectTypeWithValueType Method
+- [#174](https://github.com/dasch-swiss/dsp-ui-lib/pull/174) Confirmation Dialog Message Subcomponent
+- [#170](https://github.com/dasch-swiss/dsp-ui-lib/pull/170) Rephrase "This source belongs to project" in the resource viewer
+- [#154](https://github.com/dasch-swiss/dsp-ui-lib/pull/154) Hide system ontologies
+- [#167](https://github.com/dasch-swiss/dsp-ui-lib/pull/167) Prerelease: 1.0.0-rc.5
+- [#165](https://github.com/dasch-swiss/dsp-ui-lib/pull/165) release(prerelease): 1.0.0-rc.4
+- [#164](https://github.com/dasch-swiss/dsp-ui-lib/pull/164) dsp-property-toolbar warnings in unit tests
+- [#156](https://github.com/dasch-swiss/dsp-ui-lib/pull/156) FIX: hide the add button for an XML text property
+- [#148](https://github.com/dasch-swiss/dsp-ui-lib/pull/148) Prerelease 1.0.0-rc.3
+- [#145](https://github.com/dasch-swiss/dsp-ui-lib/pull/145) Update process of release notes
+- [#81](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/81) Add ngx-color-picker to lib's peer deps
+- [#76](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/76) Use @knora/api 1.0.0-rc.0
+- [#71](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/71) cdkTextareaAutosize code cleanup
+- [#70](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/70) Remove readonly inputs
+- [#64](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/64) Add Exports
+- [#59](https://github.com/dasch-swiss/knora-ui-ng-lib/pull/59) Add missing config files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,9 +1597,9 @@
       }
     },
     "@dasch-swiss/dsp-js": {
-      "version": "1.0.0-rc.19",
-      "resolved": "https://registry.npmjs.org/@dasch-swiss/dsp-js/-/dsp-js-1.0.0-rc.19.tgz",
-      "integrity": "sha512-GF3qms7ouXWLVtW4h3EOiWdzO3c1wn1FmubItsEILe61z5oiXfcNWL+JODPd9jAD/uKdvqg6ZqmpO7TRfwLaXA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dasch-swiss/dsp-js/-/dsp-js-1.0.0.tgz",
+      "integrity": "sha512-CcXERA79DPYhx3qApMUcKgtli/sKTR17FC4wFAY8axDrCzOSpeXXh8Gc56lkNaghqUot0oMLPXpnGZ+Sk1SLZw==",
       "requires": {
         "@types/jsonld": "^1.5.0",
         "json2typescript": "1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -312,6 +312,12 @@
             "ms": "^2.1.1"
           }
         },
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "dev": true
+        },
         "semver": {
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
@@ -1788,6 +1794,12 @@
         "semver-intersect": "1.4.0"
       },
       "dependencies": {
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "dev": true
+        },
         "rxjs": {
           "version": "6.5.4",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
@@ -6540,9 +6552,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "injection-js": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@angular/platform-browser-dynamic": "~9.1.2",
     "@angular/router": "~9.1.2",
     "@ckeditor/ckeditor5-angular": "^1.2.3",
-    "@dasch-swiss/dsp-js": "^1.0.0-rc.19",
+    "@dasch-swiss/dsp-js": "^1.0.0",
     "ckeditor5-custom-build": "github:dasch-swiss/ckeditor_custom_build",
     "jdnconvertiblecalendar": "^0.0.5",
     "jdnconvertiblecalendardateadapter": "^0.0.13",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dsp-ui-lib",
+  "version": "1.0.0",
   "description": "Angular library to easily create a Knora/DSP user interface",
   "repository": {
     "type": "git",

--- a/projects/dsp-ui/package.json
+++ b/projects/dsp-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dasch-swiss/dsp-ui",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "1.0.0",
   "description": "Angular library to easily create a Knora/DSP user interface",
   "repository": {
     "type": "git",

--- a/projects/dsp-ui/package.json
+++ b/projects/dsp-ui/package.json
@@ -21,7 +21,7 @@
     "@angular/core": "^9.0.0",
     "@angular/material": "^9.0.0",
     "@angular/cdk": "^9.0.0",
-    "@dasch-swiss/dsp-js": "1.0.0-rc.19",
+    "@dasch-swiss/dsp-js": "^1.0.0",
     "jdnconvertiblecalendar": "^0.0.5",
     "jdnconvertiblecalendardateadapter": "^0.0.13",
     "ngx-color-picker": "^10.0.1",

--- a/vars.mk
+++ b/vars.mk
@@ -1,1 +1,1 @@
-API_VERSION := v13.0.0-rc.24
+API_VERSION := v13.0.0-rc.25


### PR DESCRIPTION
To run [release-please-action](https://github.com/marketplace/actions/release-please-action) (from PR #243) the correct way, we have to do a real release first. Otherwise the mentioned action script will not work properly with all the release candidates.
In this PR I updated DSP-JS to latest version 1.0.0 (which works fine with DSP-API 13.0.0-rc.25) and I fixed some dependency security issues.