### PR TITLE
chore(github-ci): try to validate PR titles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,15 @@ jobs:
     # Automate releases with Conventional Commit Messages as Pull Requests are merged into "main" branch
     if: github.ref == 'refs/heads/main'
     steps:
+      - uses: deepakputhraya/action-pr-title@v1.0.1
+        with:
+          regex: '([a-z])+\/([a-z])+' # Regex the title should match.
+          allowed_prefixes: 'feature,fix,JIRA' # title should start with the given prefix
+          disallowed_prefixes: 'feat/,hotfix' # title should not start with the given prefix
+          prefix_case_sensitive: false # title prefix are case insensitive
+          min_length: 5 # Min length of the title
+          max_length: 20 # Max length of the title
+          github_token: ${{ secrets.GH_TOKEN }} # Default: ${{ github.token }}
       - uses: GoogleCloudPlatform/release-please-action@v2
         with:
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,11 +76,10 @@ jobs:
       - uses: actions/checkout@v2
       - run: docker build .
 
-  release-please:
-    name: Prepare next release
+  check-pr-title:
+    name: Check PR title
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    # Automate releases with Conventional Commit Messages as Pull Requests are merged into "main" branch
-    if: github.ref == 'refs/heads/main'
     steps:
       - uses: deepakputhraya/action-pr-title@v1.0.1
         with:
@@ -91,6 +90,13 @@ jobs:
           min_length: 5 # Min length of the title
           max_length: 20 # Max length of the title
           github_token: ${{ secrets.GH_TOKEN }} # Default: ${{ github.token }}
+
+  release-please:
+    name: Prepare next release
+    runs-on: ubuntu-latest
+    # Automate releases with Conventional Commit Messages as Pull Requests are merged into "main" branch
+    if: github.ref == 'refs/heads/main'
+    steps:
       - uses: GoogleCloudPlatform/release-please-action@v2
         with:
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,6 @@ jobs:
 
   check-pr-title:
     name: Check PR title
-    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - uses: deepakputhraya/action-pr-title@v1.0.1


### PR DESCRIPTION
This PR tries to check PR titles [automatically](https://github.com/marketplace/actions/pull-request-title-rules?version=v1.0.1) to prevent invalid titles that lead to ignored merge commits with release please.